### PR TITLE
fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ all: wwa.long.js wwa.js
 wwa.long.js: ./src/*.ts wwa_license_comment.js
 	tsc --sourceMap ./src/wwa_main.ts -t ES5 --outDir .. --out wwa.long.js.tmp
 	cat wwa_license_comment.js wwa.long.js.tmp > $@
-	echo "\n" >> $@
+	printf '\n' >> $@
 
 wwa.link.js: wwa_license_comment.js wwa.long.js cryptojs/aes.js
-	echo "\n" >> $@
+	printf '\n' >> $@
 	cat wwa.long.js cryptojs/aes.js > $@
 
 wwa.js: wwa.link.js closure/compiler.jar


### PR DESCRIPTION
`make` を実行すると、Linuxの環境によって改行の扱いにブレが発生し、改行がエスケープされてしまうケースが発生するようです。この場合でClosure Compilerを呼び出すと、ソースマップファイルの呼び出しに失敗してしまい、 `wwa.js` が生成できない場合があります。

ここで、環境に依存しにくい `printf` を利用しました。ご確認とマージお願いします。