### PR TITLE
TypeScriptがインストールされるようにpackage.jsonを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "concat": "^1.0.3",
     "rimraf": "^2.6.2",
+    "typescript": "^2.5.3",
     "uglify-js": "^3.1.3"
   }
 }


### PR DESCRIPTION
`npm install` と `npm run build` をそのまま実行した際に、TypeScriptが無いとエラーが発生しました。

package.json を見たところ、TypeScriptの欄が無いため追加しました。