### PR TITLE
システムメッセージの問題

### DIFF
--- a/src/wwa_main.ts
+++ b/src/wwa_main.ts
@@ -2133,7 +2133,7 @@ module wwa_main {
                                 if (this._wwaData.message[wwa_data.SystemMessage1.NO_ITEM] !== "BLANK") {
                                  this._messageQueue.push( new wwa_message.MessageInfo(
                                      this._wwaData.message[wwa_data.SystemMessage1.NO_ITEM] === "" ?
-                                     "アイテムをもっていない。" : this._wwaData.message[wwa_data.SystemMessage1.NO_ITEM],
+                                     "アイテムを持っていない。" : this._wwaData.message[wwa_data.SystemMessage1.NO_ITEM],
                                      true)
                                     );
                                  };
@@ -2166,23 +2166,23 @@ module wwa_main {
                                     this.appearParts(this._yesNoChoicePartsCoord, wwa_data.AppearanceTriggerType.OBJECT, this._yesNoChoicePartsID);
                                 } else {
                                     // アイテムをボックスがいっぱい
-                                    if (this._wwaData.message[wwa_data.SystemMessage1.NO_ITEM] !== "BLANK") {
+                                    if (this._wwaData.systemMessage[wwa_data.SystemMessage2.FULL_ITEM] !== "BLANK") {
                                         this._messageQueue.push(
                                             new wwa_message.MessageInfo(
-                                                this._wwaData.message[wwa_data.SystemMessage1.NO_ITEM] === "" ?
-                                                    "これ以上、アイテムを持てません。" : this._wwaData.message[wwa_data.SystemMessage1.NO_ITEM],
+                                                this._wwaData.systemMessage[wwa_data.SystemMessage2.FULL_ITEM] === "" ?
+                                                    "これ以上、アイテムを持てません。" : this._wwaData.systemMessage[wwa_data.SystemMessage2.FULL_ITEM],
                                                 true
                                             )
                                         );
                                     }
                                 }
                             } else {
-                                // 所持金が足りない
+                                // 所持金がたりない
                                 if (this._wwaData.message[wwa_data.SystemMessage1.NO_MONEY] !== "BLANK") {
                                     this._messageQueue.push(
                                         new wwa_message.MessageInfo(
                                         this._wwaData.message[wwa_data.SystemMessage1.NO_MONEY] === "" ?
-                                            "所持金が足りない。" : this._wwaData.message[wwa_data.SystemMessage1.NO_MONEY],
+                                            "所持金がたりない。" : this._wwaData.message[wwa_data.SystemMessage1.NO_MONEY],
                                             true
                                             )
                                     );


### PR DESCRIPTION
バグ報告掲示板にて?という名前でお世話になりました。こちらでも厄介になります。
2年前に見つけた不具合報告を失念したまま忘れてしまったため、W3.15dβ2にて再度確認の上で報告いたします。
WWAWのバージョンはW3.15dβ2　動作環境はFirefox Developer Edition 57.0です。
WWAのバージョンは3.11　Javaのバージョンは1.8です。


システムメッセージの表示に本家と違いがあります。
物を買うときに所持金が足りない場合のメッセージ
WWA Wing「所持金が足りない。」
WWA「所持金がたりない。」
物を売るときにアイテムを持っていない場合のメッセージ
WWA Wing「アイテムをもっていない。」
WWA「アイテムを持っていない。」


物体「物を売る」からアイテムが持ちきれない時に表示するメッセージが、
「物を売るときにアイテムを持っていない場合のメッセージ」に設定されています。
また、BLANKの判定についても「物を売るときにアイテムを持っていない場合のメッセージ」でした。
WWAでは、この場合「アイテムがこれ以上持てないときの確認メッセージ」です。
マップ作成ツールでシステムメッセージを変更しないとこの現象は確認できないので注意してください。