### PR TITLE
モンスターとスコア表示の$mapの問題

### DIFF
--- a/src/wwa_parts_player.ts
+++ b/src/wwa_parts_player.ts
@@ -856,7 +856,8 @@ module wwa_parts_player {
                         // 注)ドロップアイテムがこれによって消えたり変わったりするのは原作からの仕様
                         this._wwa.appearParts(this._enemy.position, wwa_data.AppearanceTriggerType.OBJECT, this._enemy.partsID);
                         this._state = PlayerState.CONTROLLABLE; // メッセージキューへのエンキュー前にやるのが大事!!(エンキューするとメッセージ待ちになる可能性がある）
-                        this._wwa.setMessageQueue(this._enemy.message, false, false);
+                        // モンスターとスコア表示の$mapの問題
+                        this._wwa.setMessageQueue(this._enemy.message, false, false, this._enemy.partsID, false, this._enemy.position);
                         this._enemy.battleEndProcess();
                         this._battleTurnNum = 0;
                         this._enemy = null;


### PR DESCRIPTION
モンスターとスコア表示の場合は、$mapの引数に指定したX座標とY座標について、相対座標(+ or -)で設定したにも関わらず、絶対座標として判定されています。
パーツ出現は問題ありませんでした。
java版は正常に動作していたため、wingの不具合と判断しました。
原因を特定したため、プルリクエストしました。