### PR TITLE
.gitignoreに.ideaとwwa.long.js系を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .vscode
+
 node_modules/
 wwa.long.js
 wwa.long.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+.idea
 .vscode
 node_modules/
+wwa.long.js
+wwa.long.js.map


### PR DESCRIPTION
WebStormとかのJetbrains系のIDEを使用した際に生成される `.idea` とビルドの成果物である `wwa.long.js` が `.gitignore` に含まれていないです。

このPull requestは `.gitignore` にこれらのファイルを追加したものです。