### PR TITLE
クラシックモードのCSSにカバー部品のセレクタを追加

### DIFF
--- a/packages/assets/style/wwa_classic.css
+++ b/packages/assets/style/wwa_classic.css
@@ -513,6 +513,72 @@ div.item-disp {
     cursor: pointer; */
 }
 
+#wwa-cover>#version {
+    position: absolute;
+    top: 392px;
+    left: 0;
+    height: 16px;
+    font-size: 12px;
+    color: #000000;
+}
+
+#wwa-cover>#progress-message-container {
+   position: absolute;
+   top: 408px;
+   left: 0;
+   width: 560px;
+   height: 16px;
+   color: #000000;
+   font-size: 12px;
+   overflow: hidden;
+   text-align: left;
+   z-index: 305;
+}
+
+#wwa-cover>#progress-bar-bg {
+   position: absolute;
+   top: 424px;
+   left: 0;
+   width: 560px;
+   height: 16px;
+   background-color: #808080;
+   z-index: 310;
+}
+
+#wwa-cover>.progress-bar {
+   position: absolute;
+   top: 424px;
+   left: 0;
+   width: 0;
+   height: 16px;
+}
+
+#wwa-cover>#progress-bar {
+   background-color: #00FF90;
+   z-index: 315;
+}
+
+#wwa-cover>#progress-bar-audio {
+   background-color: #008aff;
+   z-index: 316;
+   
+}
+
+#wwa-cover>#progress-disp {
+   position: absolute;
+   top: 424px;
+   left: 440px;
+   width: 120px;
+   height: 16px;
+   background-color: #FF6A00;
+   color: #FFFFFF;
+   text-align: center;
+   font-weight: bold;
+   z-index: 320;
+   font-size: 12px;
+   overflow: hidden;
+}
+
 #wwa-audio-wrapper {
     position: absolute;
     top: 0;


### PR DESCRIPTION
クラシックモードのCSSに、プログレスバーのようなカバー画像と一緒に付く部品のCSSセレクタが付いていません。

そのため、下記画像のように、上部に読み込み状況のメッセージが表示されてしまいます。この場合、WWA外側(ページ下部)に書いてあるテキストは隠れてしまいます。

![wwa_classic_mode_with_cover_bug](https://user-images.githubusercontent.com/12381375/45957815-e5caf400-c050-11e8-92ef-3e08d196d5a9.png)

このプルリクエストはそのCSSセレクタを追加する形で修正するものとなります。