### PR TITLE
fix(_getCandidateCoord): パーツの移動候補処理が消えていたので直す

### DIFF
--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -3611,22 +3611,22 @@ export class WWA {
 
         if (moveType === MoveType.CHASE_PLAYER) {
             dx =
-                currentCoord.x > playerNextCoord.x ? 1 :
-                    currentCoord.x < playerNextCoord.x ? -1 : 0;
-            dy =
-                currentCoord.y > playerNextCoord.y ? 1 :
-                    currentCoord.y < playerNextCoord.y ? -1 : 0;
-
-        } else if (moveType === MoveType.RUN_OUT) {
-            dx =
                 currentCoord.x > playerNextCoord.x ? -1 :
                     currentCoord.x < playerNextCoord.x ? 1 : 0;
             dy =
                 currentCoord.y > playerNextCoord.y ? -1 :
                     currentCoord.y < playerNextCoord.y ? 1 : 0;
+
+        } else if (moveType === MoveType.RUN_OUT) {
+            dx =
+                currentCoord.x > playerNextCoord.x ? 1 :
+                    currentCoord.x < playerNextCoord.x ? -1 : 0;
+            dy =
+                currentCoord.y > playerNextCoord.y ? 1 :
+                    currentCoord.y < playerNextCoord.y ? -1 : 0;
         }
-        candidateCoord.x -= dx;
-        candidateCoord.y -= dy;
+        candidateCoord.x += dx;
+        candidateCoord.y += dy;
 
         candidateCoord.x = Math.min(this._wwaData.mapWidth - 1, Math.max(0, candidateCoord.x));
         candidateCoord.y = Math.min(this._wwaData.mapWidth - 1, Math.max(0, candidateCoord.y));

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -3609,6 +3609,23 @@ export class WWA {
         var dy = 0;
 
 
+        if (moveType === MoveType.CHASE_PLAYER) {
+            dx =
+                currentCoord.x > playerNextCoord.x ? 1 :
+                    currentCoord.x < playerNextCoord.x ? -1 : 0;
+            dy =
+                currentCoord.y > playerNextCoord.y ? 1 :
+                    currentCoord.y < playerNextCoord.y ? -1 : 0;
+
+        } else if (moveType === MoveType.RUN_OUT) {
+            dx =
+                currentCoord.x > playerNextCoord.x ? -1 :
+                    currentCoord.x < playerNextCoord.x ? 1 : 0;
+            dy =
+                currentCoord.y > playerNextCoord.y ? -1 :
+                    currentCoord.y < playerNextCoord.y ? 1 : 0;
+        }
+        candidateCoord.x -= dx;
         candidateCoord.y -= dy;
 
         candidateCoord.x = Math.min(this._wwaData.mapWidth - 1, Math.max(0, candidateCoord.x));


### PR DESCRIPTION
# 概要
「プレイヤー追尾」「逃げる」移動属性パーツの移動先座標の候補生成処理が抜けてしまっていたので修正

## 動作確認 (Chrome 70 Linux)
- PLiCyさんの最終版、マージ前のdevelopの関数の処理内容が同一
- スタンダードマップの「レッツダンシン！」が正常に動く