### PR TITLE
fix(_drawPlayer): ゲーム開始時やジャンプゲート移動後にプレイヤーの足踏み動作が入らない

### DIFF
--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -2005,7 +2005,6 @@ export class WWA {
 
         if (this._player.isLookingAround() && !this._player.isWaitingMessage()) {
             crop = this._wwaData.playerImgPosX + dirChanger[Math.floor(this._mainCallCounter % 64 / 8)];
-            crop = this._wwaData.playerImgPosX + relpcrop + 1;
         } else if (this._player.isMovingImage()) {
             crop = this._wwaData.playerImgPosX + relpcrop + 1;
         } else {


### PR DESCRIPTION
マージミスと思われます: https://github.com/WWAWing/WWAWing/commit/227b2784f4e1659d72038df0431cdd83a5b10fb4#diff-0891ded59d04cf6617a425ea86b9bfcfR1953

PLiCy版にも同様の不具合が入っていると思われます

close #102

## 動作確認 (Chrome 73 Mac)
- [x] 足ふみ操作が入る