### PR TITLE
fix(updateCSSRule): メッセージの先頭にある空白文字がスタイル上表示されない問題

### DIFF
--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -3658,30 +3658,25 @@ export class WWA {
                 }
             }
         }
+        const messageWindowStyleSelector = "div.wwa-message-window, div#wwa-battle-estimate, div#wwa-password-window";
+        const messageWindowStyleRules = `
+background-color: rgba(${this._wwaData.frameColorR},  ${this._wwaData.frameColorG}, ${this._wwaData.frameColorB}, ${messageOpacity});
+border-color: rgba(${this._wwaData.frameOutColorR}, ${this._wwaData.frameOutColorG}, ${this._wwaData.frameOutColorB }, 1);
+color: rgba(${this._wwaData.fontColorR}, ${this._wwaData.fontColorG}, ${this._wwaData.fontColorB}, 1);
+white-space: pre-wrap;
+`;
+        const sidebarStyleSelector = "div#wwa-sidebar";
+        const sidebarStyleRules = `
+color: rgba(${this._wwaData.statusColorR}, ${this._wwaData.statusColorG}, ${this._wwaData.statusColorB},1);
+font-weight: bold;
+`;
+
         if (this._sheet.addRule !== void 0) {
-            this._stylePos[SelectorType.MESSAGE_WINDOW] = this._sheet.addRule(
-                "div.wwa-message-window, div#wwa-battle-estimate, div#wwa-password-window",
-                "background-color: rgba(" + this._wwaData.frameColorR + "," + this._wwaData.frameColorG + "," + this._wwaData.frameColorB + ", " + messageOpacity + ");" +
-                "border-color: rgba(" + this._wwaData.frameOutColorR + "," + this._wwaData.frameOutColorG + "," + this._wwaData.frameOutColorB + ", 1);" +
-                "color: rgba(" + this._wwaData.fontColorR + "," + this._wwaData.fontColorG + "," + this._wwaData.fontColorB + ", 1);"
-            );
-            this._stylePos[SelectorType.SIDEBAR] = this._sheet.addRule(
-                "div#wwa-sidebar",
-                "color: rgba(" + this._wwaData.statusColorR + "," + this._wwaData.statusColorG + "," + this._wwaData.statusColorB + ",1);" +
-                "font-weight: bold;"
-            );
+            this._stylePos[SelectorType.MESSAGE_WINDOW] = this._sheet.addRule(messageWindowStyleSelector,messageWindowStyleRules);
+            this._stylePos[SelectorType.SIDEBAR] = this._sheet.addRule(sidebarStyleSelector, sidebarStyleRules);
         } else {
-            this._stylePos[SelectorType.MESSAGE_WINDOW] = this._sheet.insertRule(
-                "div.wwa-message-window, div#wwa-battle-estimate, div#wwa-password-window {\n" +
-                "background-color: rgba(" + this._wwaData.frameColorR + "," + this._wwaData.frameColorG + "," + this._wwaData.frameColorB + ", " + messageOpacity + ");\n" +
-                "border-color: rgba(" + this._wwaData.frameOutColorR + "," + this._wwaData.frameOutColorG + "," + this._wwaData.frameOutColorB + ", 1);\n" +
-                "color: rgba(" + this._wwaData.fontColorR + "," + this._wwaData.fontColorG + "," + this._wwaData.fontColorB + ", 1);\n" +
-                "}", 0);
-            this._stylePos[SelectorType.SIDEBAR] = this._sheet.insertRule(
-                "div#wwa-sidebar {\n" +
-                "color: rgba(" + this._wwaData.statusColorR + "," + this._wwaData.statusColorG + "," + this._wwaData.statusColorB + ",1);\n" +
-                "font-weight: bold;\n" +
-                "}", 1);
+            this._stylePos[SelectorType.MESSAGE_WINDOW] = this._sheet.insertRule(`${messageWindowStyleSelector} { ${messageWindowStyleRules} }`, 0);
+            this._stylePos[SelectorType.SIDEBAR] = this._sheet.insertRule(`${sidebarStyleSelector} { ${sidebarStyleRules} }`, 1);
         }
     }
     public changeStyleRule(type: ChangeStyleType, r: number, g: number, b: number) {

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -3644,7 +3644,6 @@ export class WWA {
         this.updateCSSRule();
     }
     public updateCSSRule() {
-        var messageOpacity = this._isClassicModeEnable ? 1 : 0.9;
         if (this._stylePos === void 0) {
             this._stylePos = new Array(2);
         } else {
@@ -3659,8 +3658,9 @@ export class WWA {
             }
         }
         const messageWindowStyleSelector = "div.wwa-message-window, div#wwa-battle-estimate, div#wwa-password-window";
+        const messageWindowOpacity = this._isClassicModeEnable ? 1 : 0.9;
         const messageWindowStyleRules = `
-background-color: rgba(${this._wwaData.frameColorR},  ${this._wwaData.frameColorG}, ${this._wwaData.frameColorB}, ${messageOpacity});
+background-color: rgba(${this._wwaData.frameColorR},  ${this._wwaData.frameColorG}, ${this._wwaData.frameColorB}, ${messageWindowOpacity});
 border-color: rgba(${this._wwaData.frameOutColorR}, ${this._wwaData.frameOutColorG}, ${this._wwaData.frameOutColorB }, 1);
 color: rgba(${this._wwaData.fontColorR}, ${this._wwaData.fontColorG}, ${this._wwaData.fontColorB}, 1);
 white-space: pre-wrap;


### PR DESCRIPTION
メッセージ（パーツの他、システムメッセージ含む）ダイアログの行頭の空白文字（半角スペースやタブなど）がCSSのスタイル都合で省略されてしまう不具合に対応します。

ついでに重複しているコードの共通化などを行っています

## 動作確認
Chrome 73 Windows / Firefox 65 Windows
- [x] 先頭に半角スペースがあるメッセージについて、半角スペースが表示される
- [x] $color マクロが効く