### PR TITLE
[cherry-pick] クラシックモードのCSSにカバー部品のセレクタを追加

### DIFF
--- a/packages/assets/style/wwa_classic.css
+++ b/packages/assets/style/wwa_classic.css
@@ -523,6 +523,72 @@ div.item-disp {
     cursor: pointer; */
 }
 
+#wwa-cover>#version {
+    position: absolute;
+    top: 392px;
+    left: 0;
+    height: 16px;
+    font-size: 12px;
+    color: #000000;
+}
+
+#wwa-cover>#progress-message-container {
+   position: absolute;
+   top: 408px;
+   left: 0;
+   width: 560px;
+   height: 16px;
+   color: #000000;
+   font-size: 12px;
+   overflow: hidden;
+   text-align: left;
+   z-index: 305;
+}
+
+#wwa-cover>#progress-bar-bg {
+   position: absolute;
+   top: 424px;
+   left: 0;
+   width: 560px;
+   height: 16px;
+   background-color: #808080;
+   z-index: 310;
+}
+
+#wwa-cover>.progress-bar {
+   position: absolute;
+   top: 424px;
+   left: 0;
+   width: 0;
+   height: 16px;
+}
+
+#wwa-cover>#progress-bar {
+   background-color: #00FF90;
+   z-index: 315;
+}
+
+#wwa-cover>#progress-bar-audio {
+   background-color: #008aff;
+   z-index: 316;
+   
+}
+
+#wwa-cover>#progress-disp {
+   position: absolute;
+   top: 424px;
+   left: 440px;
+   width: 120px;
+   height: 16px;
+   background-color: #FF6A00;
+   color: #FFFFFF;
+   text-align: center;
+   font-weight: bold;
+   z-index: 320;
+   font-size: 12px;
+   overflow: hidden;
+}
+
 #wwa-audio-wrapper {
     position: absolute;
     top: 0;


### PR DESCRIPTION
#60 の 内容を v3.1.7 にも含めます。