### PR TITLE
[fix] BGMの再生処理をBGM以外で起こさないように修正

### DIFF
--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -1110,6 +1110,11 @@ export class WWA {
         const audioInstance = this._audioInstances[id];
         if (!audioInstance.hasData()) {
             if (id >= SystemSound.BGM_LB) {
+                /**
+                 * 音楽ファイルの存在確認を頻繁に行うように設定します。
+                 * @param id 
+                 * @param self 
+                 */
                 var loadi = ((id: number, self: WWA): void => {
                     var timer = setInterval((): void => {
                         if (self._wwaData.bgm === id) {
@@ -1127,12 +1132,9 @@ export class WWA {
                     }, 4);
                 });
                 loadi(id, this);
+                this._wwaData.bgm = id;
             }
-            this._wwaData.bgm = id;
-            return;
-        }
-
-        if (id !== 0 && this._audioInstances[id].hasData()) {
+        } else {
             if (id >= SystemSound.BGM_LB) {
                 this._audioInstances[id].play();
                 this._wwaData.bgm = id;
@@ -1140,7 +1142,6 @@ export class WWA {
                 this._audioInstances[id].play();
             }
         }
-
 
     }
 


### PR DESCRIPTION
存在しない効果音が見つかった後に、BGMの再生処理が入ると2重で再生されることがあるため、そのための修正になります。

まだ動作確認は行っていないので、近いうちに行います。