### PR TITLE
fix(gameover): ゲームオーバー前に予約しているマクロを破棄する

### DIFF
--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -3009,6 +3009,7 @@ export class WWA {
 
         this._waitFrame = 0;
         this._temporaryInputDisable = true;
+        this._execMacroListInNextFrame = [];
         this._player.jumpTo(new Position(this, jx, jy, 0, 0));
     }
 


### PR DESCRIPTION
closes #121 

ゲームオーバー時に、ゲームオーバー前に実行予定だったマクロ情報を破棄し、不正な物体配置が起こらないようにします。