### PR TITLE
fix(debug-server): package.json の generate コマンドに shx を追加

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   base = "/"
   publish = "packages/engine/lib"
-  command = "npm install && npm run build && npm run deploy"
+  command = "npm install && npm run deploy"

--- a/packages/debug-server/package.json
+++ b/packages/debug-server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "npm run build && node lib debug",
     "build": "tsc -p .",
-    "generate": "mkdir -p bin && nexe --target=win32-x86-8.6.0 --cwd . --output bin/wwa-server.exe",
+    "generate": "shx mkdir -p bin && nexe --target=win32-x86-8.6.0 --cwd . --output bin/wwa-server.exe",
     "clean": "shx rm -rf debug lib bin",
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "npm run build && npm run generate"


### PR DESCRIPTION
## 理由
- Windows で `npm run boostrap` を実行すると、 debug-server の nexe の実行に失敗するため (下記参照)

```
> @wwawing/debug-server@3.2.3 generate C:\WWAWing\packages\debug-server
> mkdir -p bin && nexe --target=win32-x86-8.6.0 --cwd . --output bin/wwa-server.exe
サブディレクトリまたはファイル -p は既に存在します。
処理中にエラーが発生しました: -p
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @wwawing/debug-server@3.2.3 generate: `mkdir -p bin && nexe --target=win32-x86-8.6.0 --cwd . --output bin/wwa-server.exe`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @wwawing/debug-server@3.2.3 generate script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

- Netlify で build が2回実行されてしまう不具合の修正