### PR TITLE
feat(_window): 複数QuickSaveのsass移植

### DIFF
--- a/packages/styles/src/core/_window.scss
+++ b/packages/styles/src/core/_window.scss
@@ -155,8 +155,29 @@ div.savedata {
         border-color: #FF0000;
     }
     > div.wide-cell-row {
+        // TODO: _sidebar にいる %wide-cell と共通化できる部分を共通化したい
+        padding: 10px 0 0 0;
+        margin: 0px;
+        border: 0px;
+        width: 120px;
+        height: 25px;
+        font-size: 14px;
         position: relative;
         pointer-events: none;
+        > div.status-icon {
+            // TODO: _sidebar にいる %item_cell をどこからでも使える場所において、それを使うようにする。
+            // @extend %item_cell; // ここから
+            position: absolute;
+            width: 40px;
+            height: 40px;
+            // ここまで
+
+            top: 0;
+            left: 6px; // $wwa_status_x_offset
+
+            padding: 0;
+            margin: 0;
+        }
     }
     > div.ss {
         display: inline-block;


### PR DESCRIPTION
`feature/plicy-2019` #175 向けです。

PLiCyバージョンより、複数QuickSaveのスタイルを移植します。
WingはSassになっているので、書き方を改めています。
ステータスなどが出ないのは後続のコミットを取り込んでいないからなので、後々直ります