### PR TITLE
fix(user-device): iPadOS 上 Safari がデフォルトでPC扱いされる不具合

### DIFF
--- a/packages/engine/src/wwa_data.ts
+++ b/packages/engine/src/wwa_data.ts
@@ -370,7 +370,11 @@ export class UserDevice {
             return OS_TYPE.WINDOWS;
         }
         if (ua.match(/macintosh/i)) {
-            return OS_TYPE.MACINTOSH;
+            // iPadOS において、デフォルトで Safari は PC向けサイトを表示する設定になっている。
+            // その場合、 ユーザエージェント は Macintosh 扱いとなる。
+            // ここでは、touchStart イベントが実装されているかどうかを見て iPadOS か macOSかを判定する。
+            // (2020-06-07 現在、タッチパネルが搭載されたmac端末は発売されていないため、macOS を iPad に誤検知することは起こりにくいはず。)
+            return "ontouchstart" in document ? OS_TYPE.IOS : OS_TYPE.MACINTOSH;
         }
         if (ua.match(/iphone|ipad|ipod/i)) {
             return OS_TYPE.IOS;


### PR DESCRIPTION
## 動作確認
- [x] iPadOS 環境でデスクトップ用サイト表示設定のON/OFFに関わらずボタンが拡大される
- [x] macOS 環境で Chrome, Firefox, Chromium Edge においてボタンが拡大されない