### PR TITLE
fix(engine): data-wwa-autosave=0 の有効化

### DIFF
--- a/packages/engine/src/wwa_save/WWASaveDataLogList.ts
+++ b/packages/engine/src/wwa_save/WWASaveDataLogList.ts
@@ -49,6 +49,10 @@ export default class WWASaveDataLogList extends WWASaveDataList {
         this._saveNo = this._saveNo % WWASaveConsts.QUICK_SAVE_MAX;
     }
     public setAutoSaveInterval(autoInterval: number): void {
+        if (autoInterval < 0) {
+            console.warn(`オートセーブの歩数 (${autoInterval}) に負の値が設定されています。`);
+            return;
+        }
         this._autoInterval = autoInterval | 0;
     } 
 }

--- a/packages/engine/src/wwa_save/WWASaveDataLogList.ts
+++ b/packages/engine/src/wwa_save/WWASaveDataLogList.ts
@@ -49,9 +49,6 @@ export default class WWASaveDataLogList extends WWASaveDataList {
         this._saveNo = this._saveNo % WWASaveConsts.QUICK_SAVE_MAX;
     }
     public setAutoSaveInterval(autoInterval: number): void {
-        if (autoInterval <= 0) {
-            return;
-        }
         this._autoInterval = autoInterval | 0;
     } 
 }


### PR DESCRIPTION
Close: #295 

開発モードで packages/engine/lib/ 下の Standard Map (wwamap.html) を編集し、 `data-wwa-autosave=0` に差し替えた状態で動作確認をしました。