### PR TITLE
docs: Edge レガシのサポート終了

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ npm install
 OSは不問です。
 
 - Microsoft Internet Explorer 11
-- Microsoft Edge (EdgeHTML 18) ※Microsoft Edge レガシ は遅くとも2021年3月9日までにサポートを終了します。今後は Chromium 版 Edge の利用を強くおすすめします。
 - Mozilla Firefox (最新版)
-- Google Chrome/Chromium (最新版) ※Microsoft Edgeの最新版を含む
+- Google Chrome/Chromium (最新版) ※ Microsoft Edge の最新版など Chromium ベースのブラウザを含む
 - Safari (最新版)
 
 ### スマートフォン・タブレット

--- a/packages/assets/html/manual.html
+++ b/packages/assets/html/manual.html
@@ -398,9 +398,8 @@
                 OSは不問です。
                 <ul>
                     <li>Microsoft Internet Explorer 11</li>
-                    <li>Microsoft Edge (EdgeHTML 18) ※Microsoft Edge レガシ は遅くとも2021年3月9日までにサポートを終了します。今後は Chromium 版 Edge の利用を強くおすすめします。</li>
                     <li>Mozilla Firefox (最新版)</li>
-                    <li>Google Chrome/Chromium (最新版) ※Microsoft Edgeの最新版を含む</li>
+                    <li>Google Chrome/Chromium (最新版) ※ Microsoft Edge の最新版など Chromium ベースのブラウザを含む</li>
                     <li>Safari (最新版)</li>
                 </ul>
                 <h3>スマートフォン・タブレット</h3>


### PR DESCRIPTION
Microsoft Edge レガシ (レンダリングエンジン EdgeHTML 18以下) は 本日 2021-03-09 をもって Microsoft 社によるサポートが終了するため、WWA Wing としても、次回のリリースよりサポートを取りやめます。

Edge対応のための機能は今後順次削除予定ですが、本PRではマニュアルのサポートブラウザの内容のみを変更します。
