### PR TITLE
chore(loader): MapDataClient を axios による実装に変更

### DIFF
--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -40,7 +40,8 @@
   },
   "homepage": "https://github.com/WWAWing/WWALoader#readme",
   "dependencies": {
-    "@wwawing/event-emitter": "^3.5.9"
+    "@wwawing/event-emitter": "^3.5.9",
+    "axios": "0.21.1"
   },
   "devDependencies": {
     "@wwawing/common-interface": "^3.5.9",

--- a/packages/loader/src/core/map-data-client/index.ts
+++ b/packages/loader/src/core/map-data-client/index.ts
@@ -1,56 +1,51 @@
+import axios from "axios";
+
 export class MapDataClient {
   constructor(private fileName: string) {}
   
   public request(callback: (error?: any, data?: any) => any): void {
-    const xhr: XMLHttpRequest = new XMLHttpRequest();
     try {
       // TODO: XHR をやめて、nodeでも動くようにする
       // 例えば、axiosを導入すればどちらでも動くコードにできるはず
       // (Promise を IE11で使えるようにするためにengine側で @babel/preset-env をかける必要があるので注意)
       // (この場合は、ライセンス表記に「axios」「core-js」を増やす必要があることに注意 どちらもMIT)
-      xhr.open("GET", this.fileName, true);
-      xhr.responseType = "arraybuffer";
-
-      xhr.onreadystatechange = () => {
-        try {
-          if (xhr.readyState === XMLHttpRequest.DONE) {
-            if (xhr.status === 200 || xhr.status === 304) {
-              callback(undefined, xhr.response)
-            } else if (xhr.status === 404) {
-              throw new Error(
-                "マップデータ「" +
-                this.fileName +
-                "」が見つかりませんでした。\n" +
-                "HTTPステータスコードは " +
-                xhr.status +
-                "です。"
-              );
-            } else if (xhr.status === 403) {
-              throw new Error(
-                "マップデータ「" +
-                this.fileName +
-                "」を読み取る権限がないようです。\n" +
-                "管理者の方へ: マップデータのパーミッションを確認してください。\n" +
-                "HTTPステータスコードは " +
-                xhr.status +
-                "です。"
-              );
-            } else {
-              throw new Error(
-                "マップデータ「" +
-                this.fileName +
-                "」の読み込みに失敗しました。\n" +
-                "HTTPステータスコードは " +
-                xhr.status +
-                "です。"
-              );
-            }
+      axios.get(this.fileName, { responseType: 'arraybuffer' })
+        .then(value => {
+          if (value.status == 200 || value.status == 304) {
+            callback(undefined, value.data);
+          } else if (value.status == 404) {
+            throw new Error(
+              "マップデータ「" +
+              this.fileName +
+              "」が見つかりませんでした。\n" +
+              "HTTPステータスコードは " +
+              value.status +
+              "です。"
+            );
+          } else if (value.status == 403) {
+            throw new Error(
+              "マップデータ「" +
+              this.fileName +
+              "」を読み取る権限がないようです。\n" +
+              "管理者の方へ: マップデータのパーミッションを確認してください。\n" +
+              "HTTPステータスコードは " +
+              value.status +
+              "です。"
+            );
+          } else {
+            throw new Error(
+              "マップデータ「" +
+              this.fileName +
+              "」の読み込みに失敗しました。\n" +
+              "HTTPステータスコードは " +
+              value.status +
+              "です。"
+            );
           }
-        } catch (error) {
-          callback(error)
-        }
-      };
-      xhr.send(null);
+        }).catch(reason => {
+          callback(reason);
+        });
+
     } catch (e) {
       callback(new Error(
         "ロードエラー: ローカルテストの場合は、ブラウザが対応していない可能性があります。\n" +


### PR DESCRIPTION
WWA Loader では XMLHttpRequest によりマップデータファイルを読み込んでいますが、 Node.js で実行する場合は XMLHttpRequest が使用できないため正常にマップデータファイルを読み込むことができません。

ブラウザー側では XMLHttpRequest で、 Node.js では Http モジュールで読み込みができるようになる axios を使用して WWA Loader の実装を変更します。

## 動作チェック
- [x] axios に差し替え
- [ ] Polyfill の追加
- [ ] ライセンスコメントの追加