### PR TITLE
refactor(release): SSHキーのセットアップをやめた

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: "Install SSH Key for WWAWing/sites"
-        uses: "shimataro/ssh-key-action@v2"
-        with:
-          key: ${{ secrets.SSH_KEY }}
-          name: id_ed25519
-          known_hosts: ${{ secrets.KNOWN_HOSTS }}
-
       - name: "Set Env"
         run: "echo \"WWA_WING_VERSION=$(node -e \"console.log(require('./packages/engine/package.json').version)\")\" >> $GITHUB_ENV"
 


### PR DESCRIPTION
#361 でSSHキーが不要になったので、secretsから削除するとともに、ワークフローからも削除します