### PR TITLE
fix(loader): ユーザ変数・プレイ時間・スピード変更許可フラグ初期化をloaderへ移動

### DIFF
--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -332,20 +332,8 @@ export class WWA {
             pathList.push(this._wwaData.mapCGName); //最後に画像ファイル名を追加
             this._wwaData.mapCGName = pathList.join("/");  //pathを復元
 
-            /* WWAWing XE 拡張部分 */
-            //
-            this._wwaData.permitChangeGameSpeed = true;
-            this._wwaData.userVar = new Array(Consts.USER_VAR_NUM);
-            for (var i = 0; i < Consts.USER_VAR_NUM; i++) {
-                this._wwaData.userVar[i] = 0;
-            }
             // プレイ時間関連
-            this._wwaData.playTime = 0;
-            var _nowTime: any;
-            _nowTime = new Date();
-            this._startTime = _nowTime.getTime();
-            /* WWAWing XE 拡張部分ここまで */
-
+            this._startTime = new Date().getTime();
             this._restartData = JSON.parse(JSON.stringify(this._wwaData));
             this.checkOriginalMapString = this._generateMapDataHash(this._restartData);
 
@@ -5057,8 +5045,7 @@ font-weight: bold;
     }
     // 現在時刻セット
     private setNowPlayTime(): void {
-        var _nowTime: any;
-        _nowTime = new Date();
+        const _nowTime = new Date();
         this._wwaData.playTime += (_nowTime.getTime() - this._startTime);
         this._startTime = _nowTime.getTime();
     }

--- a/packages/loader/src/core/text-loader/index.ts
+++ b/packages/loader/src/core/text-loader/index.ts
@@ -120,6 +120,13 @@ export class TextLoader {
 
     wwaData.moves = WWAConsts.DEFAULT_MOVES;
     wwaData.gameSpeedIndex = WWAConsts.DEFAULT_SPEED_INDEX;
+    wwaData.permitChangeGameSpeed = true;
+    wwaData.userVar = new Array(WWAConsts.USER_VAR_NUM);
+    for (let i = 0; i < WWAConsts.USER_VAR_NUM; i++) {
+      wwaData.userVar[i] = 0;
+    }
+    wwaData.playTime = 0;
+
 
     return wwaData;
   }

--- a/packages/loader/src/infra/index.ts
+++ b/packages/loader/src/infra/index.ts
@@ -66,6 +66,8 @@ export class WWAConsts {
 
     static DEFAULT_MOVES = 0;
     static DEFAULT_SPEED_INDEX = 3;
+
+    static USER_VAR_NUM = 256;
 }
 
 export class LoaderError implements Error {


### PR DESCRIPTION
Restart Gameをしたときに初期化されないケースがあるので、Loaderで初期化することで、restartDataに入るようにします