### PR TITLE
feat(wwa-message): ステータスコピーマクロにオプション追加

### DIFF
--- a/packages/engine/src/wwa_data.ts
+++ b/packages/engine/src/wwa_data.ts
@@ -995,3 +995,11 @@ export enum IDTable {
     BITSHIFT = 16,
     BITMASK = 0xFFFF
 };
+
+/**
+ * ステータスの計算方法の種類
+ * all: 素手 + 装備品
+ * bare: 素手のみ
+ * equipment 装備品のみ
+ */
+export type StatusSolutionKind = "all" | "bare" | "equipment";

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -7,7 +7,7 @@ import {
     SystemSound, loadMessages, SystemMessage1, sidebarButtonCellElementID, SpeedChange, PartsType, dirToKey,
     speedNameList, dirToPos, MoveType, AppearanceTriggerType, vx, vy, EquipmentStatus, SecondCandidateMoveType,
     ChangeStyleType, MacroStatusIndex, SelectorType, IDTable, UserDevice, OS_TYPE, DEVICE_TYPE, BROWSER_TYPE, ControlPanelBottomButton, MacroImgFrameIndex, DrawPartsData,
-    speedList, StatusKind
+    speedList, StatusKind, StatusSolutionKind
 } from "./wwa_data";
 
 import {
@@ -4927,12 +4927,34 @@ font-weight: bold;
         this.setUserVar(num, this._player.getEnergyMax());
     }
     // ユーザ変数 <= AT
-    public setUserVarAT(num: number): void {
-        this.setUserVar(num, this._player.getStatus().strength);
+    public setUserVarAT(num: number, kind: StatusSolutionKind): void {
+        switch (kind) {
+            case "bare":
+                this.setUserVar(num, this._player.getStatusWithoutEquipments().strength);
+                return;
+            case "equipment":
+                this.setUserVar(num, this._player.getStatusOfEquipments().strength);
+                return;
+            case "all":
+            default:
+                this.setUserVar(num, this._player.getStatus().strength);
+                return;
+        }
     }
     // ユーザ変数 <= DF
-    public setUserVarDF(num: number): void {
-        this.setUserVar(num, this._player.getStatus().defence);
+    public setUserVarDF(num: number, kind: StatusSolutionKind): void {
+        switch (kind) {
+            case "bare":
+                this.setUserVar(num, this._player.getStatusWithoutEquipments().defence);
+                return;
+            case "equipment":
+                this.setUserVar(num, this._player.getStatusOfEquipments().defence);
+                return;
+            case "all":
+            default:
+                this.setUserVar(num, this._player.getStatus().defence);
+                return;
+        }
     }
     // ユーザ変数 <= MONEY
     public setUserVarMONEY(num: number): void {

--- a/packages/engine/src/wwa_message.ts
+++ b/packages/engine/src/wwa_message.ts
@@ -11,7 +11,8 @@ import {
     YesNoState,
     Position,
     DEVICE_TYPE,
-    Direction
+    Direction,
+    StatusSolutionKind
 } from "./wwa_data";
 import {
     Positioning as MPositioning
@@ -323,15 +324,29 @@ export class Macro {
     }
     // copy_at_toマクロ実行部
     private _executeCopyAtToMacro(): void {
-        this._concatEmptyArgs(1);
-        var num = this._parseInt(0);
-        this._wwa.setUserVarAT(num);
+        this._concatEmptyArgs(2);
+        const num = this._parseInt(0);
+        const kind = this._parseStatusKind(this._parseInt(1));
+        this._wwa.setUserVarAT(num, kind);
     }
     // copy_df_toマクロ実行部
     private _executeCopyDfToMacro(): void {
-        this._concatEmptyArgs(1);
-        var num = this._parseInt(0);
-        this._wwa.setUserVarDF(num);
+        this._concatEmptyArgs(2);
+        const num = this._parseInt(0);
+        const kind = this._parseStatusKind(this._parseInt(1));
+        this._wwa.setUserVarDF(num, kind);
+    }
+    private _parseStatusKind(kind: number): StatusSolutionKind {
+        switch (kind) {
+            case 0:
+                return "all";
+            case 1:
+                return "bare"
+            case 2:
+                return "equipment";
+            default:
+                return "all";
+        }
     }
     // copy_money_toマクロ実行部
     private _executeCopyMoneyToMacro(): void {

--- a/packages/engine/src/wwa_parts_player.ts
+++ b/packages/engine/src/wwa_parts_player.ts
@@ -533,6 +533,12 @@ export class Player extends PartsObject {
         return this._status.plus(new EquipmentStatus(0, 0));
     }
 
+    // 装備品のステータスを返す
+    public getStatusOfEquipments(): EquipmentStatus {
+        // クローンハック
+        return this._equipStatus.plus(new EquipmentStatus(0, 0));
+    }
+
     public updateStatusValueBox(): void {
         const totalStatus = this._status.plus(this._equipStatus);
         this._energyValueElement.textContent = this._wwa.isVisibleStatus("energy") ? String(totalStatus.energy) : "";


### PR DESCRIPTION
 `$copy_at_to`, `$copy_df_to` マクロに第2引数を追加します。
- 0 または無指定: 全ステータスをコピー
- 1: 素手のステータスをコピー
- 2: 装備品のみのステータスをコピー