### PR TITLE
fix(show-str): show_strマクロの変数がリアルタイムに更新されるようにした

### DIFF
--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -426,7 +426,7 @@ export class WWA {
 
             //ロード処理の前に追加
             this._messageWindow = new MessageWindow(
-                this, 50, 180, 340, 0, "", this._wwaData.mapCGName, false, true, false, util.$id("wwa-wrapper"));
+                this, 50, 180, 340, 0, this._wwaData.mapCGName, false, true, false, util.$id("wwa-wrapper"));
             this._scoreWindow = new ScoreWindow(
                 this, new Coord(50, 50), false, util.$id("wwa-wrapper"));
 
@@ -879,12 +879,12 @@ export class WWA {
                 }
 
                 if (this._usePassword) {
-                    this._messageWindow.setMessage(
+                    this._messageWindow.setMessage(new MessageInfo(
                         (
                             this._wwaData.systemMessage[SystemMessage2.LOAD_SE] === "" ?
                                 "効果音・ＢＧＭデータをロードしますか？" :
                                 this._wwaData.systemMessage[SystemMessage2.LOAD_SE]
-                        ));
+                        ), true));
                     this._messageWindow.show();
                     this._setProgressBar(getProgress(4, 4, LoadStage.GAME_INIT));
                     var timer = setInterval((): void => {
@@ -3162,7 +3162,7 @@ export class WWA {
 
             // set message
             if (!topmes.isEmpty()) {
-                this._messageWindow.setMessage(topmes.generatePrintableMessage());
+                this._messageWindow.setMessage(topmes);
                 this._messageWindow.setYesNoChoice(showChoice);
                 this._messageWindow.setPositionByPlayerPosition(
                     this._faces.length !== 0,
@@ -4433,7 +4433,7 @@ export class WWA {
             if (!mi.isEmpty()) {
                 this._player.setDelayFrame();
                 this._messageWindow.hide();
-                this._messageWindow.setMessage(mi.generatePrintableMessage());
+                this._messageWindow.setMessage(mi);
                 this._messageWindow.setPositionByPlayerPosition(
                     this._faces.length !== 0,
                     this._scoreWindow.isVisible(),
@@ -4877,7 +4877,10 @@ font-weight: bold;
         if (this.isNotNumberTypeOrNaN(index) || !this.isValidUserVarIndex(index)) {
             throw new Error (`代入先のユーザ変数の番号 が 0 以上 ${Consts.USER_VAR_NUM - 1} 以下の数値になっていません!`)
         }
-        this._wwaData.userVar[index] = this.toAssignableValue(value)
+        this._wwaData.userVar[index] = this.toAssignableValue(value);
+        
+        // メッセージボックスに表示されている変数を更新
+        this._messageWindow.update();
     }
     /**
      * 数値 x を代入可能な変数に変換する。

--- a/packages/engine/src/wwa_message.ts
+++ b/packages/engine/src/wwa_message.ts
@@ -29,16 +29,16 @@ import {
 } from "./wwa_save";
 
 export type LazyEvaluateValue = () => number
-export type MessageArray = (string | LazyEvaluateValue)[]
-export class MessageInfo {
-    private messageArray: MessageArray;
+export type MessageSegments = (string | LazyEvaluateValue)[]
+export class ParsedMessage {
+    private messageArray: MessageSegments;
     constructor(
-        messageOrMessageArray: string | MessageArray,
+        textOrMessageSegments: string | MessageSegments,
         public isSystemMessage: boolean,
         public isEndOfPartsEvent?: boolean,
         public macro?: Macro[]
     ) {
-        this.messageArray = typeof messageOrMessageArray === "string" ? [messageOrMessageArray] : messageOrMessageArray;
+        this.messageArray = typeof textOrMessageSegments === "string" ? [textOrMessageSegments] : textOrMessageSegments;
         if (this.macro === void 0) {
             this.macro = [];
         }
@@ -1055,7 +1055,7 @@ export class MessageWindow /* implements TextWindow(予定)*/ {
     private _y: number;
     private _width: number;
     private _height: number;
-    private _message: MessageInfo;
+    private _message: ParsedMessage;
 
     private _cgFileName: string;
     private _isVisible: boolean;
@@ -1100,7 +1100,7 @@ export class MessageWindow /* implements TextWindow(予定)*/ {
         this._y = y;
         this._width = width;
         this._height = height;
-        this._message = new MessageInfo([], false);
+        this._message = new ParsedMessage([], false);
         this._isVisible = isVisible;
         this._isYesno = isYesno;
         this._isItemMenu = isItemMenu;
@@ -1227,7 +1227,7 @@ export class MessageWindow /* implements TextWindow(予定)*/ {
 
     }
 
-    public setMessage(message: MessageInfo): void {
+    public setParsedMessage(message: ParsedMessage): void {
         this._message = message;
         this.update();
     }

--- a/packages/engine/src/wwa_message.ts
+++ b/packages/engine/src/wwa_message.ts
@@ -28,8 +28,19 @@ import {
     WWASaveData
 } from "./wwa_save";
 
-export type LazyEvaluateValue = () => number
-export type MessageSegments = (string | LazyEvaluateValue)[]
+/**
+ * 値が更新された時に、再評価されるべき値を返す関数の型。
+ */
+export type LazyEvaluateValue = () => number;
+/**
+ * 通常のメッセージ文字列と LazyEvaluateValue が混在した配列の型。
+ * 例: ["変数 10 番の値は", () => userVar[10], "です。\n文字列中に改行も入りえます。"]
+ */
+export type MessageSegments = (string | LazyEvaluateValue)[];
+/**
+ * パース済メッセージ。
+ * 通常のメッセージの他、マクロの情報などを持ちます。
+ */
 export class ParsedMessage {
     private messageArray: MessageSegments;
     constructor(

--- a/packages/engine/src/wwa_message.ts
+++ b/packages/engine/src/wwa_message.ts
@@ -1055,7 +1055,7 @@ export class MessageWindow /* implements TextWindow(予定)*/ {
     private _y: number;
     private _width: number;
     private _height: number;
-    private _message: string;
+    private _message: MessageInfo;
 
     private _cgFileName: string;
     private _isVisible: boolean;
@@ -1085,7 +1085,6 @@ export class MessageWindow /* implements TextWindow(予定)*/ {
         y: number,
         width: number,
         height: number,
-        message: string,
         cgFileName: string,
         isVisible: boolean,
         isYesno: boolean,
@@ -1101,7 +1100,7 @@ export class MessageWindow /* implements TextWindow(予定)*/ {
         this._y = y;
         this._width = width;
         this._height = height;
-        this._message = message;
+        this._message = new MessageInfo([], false);
         this._isVisible = isVisible;
         this._isYesno = isYesno;
         this._isItemMenu = isItemMenu;
@@ -1228,7 +1227,7 @@ export class MessageWindow /* implements TextWindow(予定)*/ {
 
     }
 
-    public setMessage(message: string): void {
+    public setMessage(message: MessageInfo): void {
         this._message = message;
         this.update();
     }
@@ -1336,7 +1335,7 @@ export class MessageWindow /* implements TextWindow(予定)*/ {
             this._ynWrapperElement.style.display = "none";
         }
         this._msgWrapperElement.textContent = "";
-        var mesArray = this._message.split("\n");
+        var mesArray = this._message.generatePrintableMessage().split("\n");
         mesArray.forEach((line, i) => {
             let lsp: HTMLSpanElement; // Logical SPan
             if (this._wwa.isClassicMode()) {

--- a/packages/engine/src/wwa_parts_player.ts
+++ b/packages/engine/src/wwa_parts_player.ts
@@ -545,6 +545,8 @@ export class Player extends PartsObject {
         this._strengthValueElement.textContent = this._wwa.isVisibleStatus("strength") ? String(totalStatus.strength) : "";
         this._defenceValueElement.textContent = this._wwa.isVisibleStatus("defence") ? String(totalStatus.defence) : "";
         this._goldValueElement.textContent = this._wwa.isVisibleStatus("gold") ? String(totalStatus.gold) : "";
+        // メッセージに表示されているステータスのアップデート
+        this._wwa._messageWindow?.update();
     }
 
     readonly itemTransitioningClassName = "item-transitioning";


### PR DESCRIPTION
#394 で show_str が早期に処理されるようになったのはよかったのだが、ユーザ変数が埋まった状態で更新されるようになっていたので、それらが更新された時にリアルタイムにメッセージウィンドウに記録されるようにする。