### PR TITLE
feat(vardump): ユーザ変数の説明ラベルを旧来の変数一覧でも表示

### DIFF
--- a/packages/all/scripts/make-wwawing-dist.ts
+++ b/packages/all/scripts/make-wwawing-dist.ts
@@ -34,7 +34,7 @@ export default async function makeDistribution(
             copy("assets", path.join("html", "manual.html")),
             copy("engine", path.join("lib", "wwa.js")),
             copy("assets", path.join("style", "*.css")),
-            copy("styles", path.join("output","*.css"))
+            copy("styles", path.join("output", "*.css"))
         ];
     } else {
         tasks = [
@@ -50,12 +50,12 @@ export default async function makeDistribution(
             copy("assets", path.join("images", "*.gif"), "mapdata"),
             copy("assets", path.join("images", "wwawing-disp.png"), "mapdata"),
             copy("debug-server", path.join("bin", "wwa-server.exe"), "mapdata"),
-            copy("styles", path.join("output","*.css"), "mapdata"),
+            copy("styles", path.join("output", "*.css"), "mapdata"),
             copy("assets", path.join("vars", "*.json"), "mapdata"),
         ];
     }
     await Promise.all(tasks);
-    if(isConvertLfToCrlf) {
+    if (isConvertLfToCrlf) {
         await convertLfToCrlfAll(isUpdate ? destUpdateBasePath : destBasePath)
     }
     console.log((isUpdate ? "update" : "full") + " version done.");
@@ -136,8 +136,9 @@ export default async function makeDistribution(
                 params.html
             ));
     }
-    
-    function createConfig(mapData: string): InputConfig {
+
+    function createConfig(mapDataName: string): InputConfig {
+        const canIncludeUserVarOptions = (mapDataName === "wwamap");
         return {
             page: {
                 additionalCssFiles: ["style.css"]
@@ -147,16 +148,20 @@ export default async function makeDistribution(
                     autoSave: {
                         intervalSteps: 200,
                     },
-                    varDump: {
-                        elementId: "vardump"
-                    },
-                    isShowUserVariable: true
+                    ... (canIncludeUserVarOptions ? {
+                        userVars: {
+                            dumpElementId: "vardump",
+                            canDisplay: true
+                        }
+                    } : {})
                 },
                 resources: {
-                    mapData: `${mapData}.dat`,
+                    mapData: `${mapDataName}.dat`,
                     wwaJs: "wwa.js",
                     titleImage: "cover.gif",
-                    userVarNamesFile: `${mapData}-vars.json`
+                    ...(canIncludeUserVarOptions ? {
+                        userVarNamesFile: `${mapDataName}-vars.json`
+                    } : {})
                 },
             },
             copyrights: "official-and-wing"

--- a/packages/engine/debug/make-debug-pages.ts
+++ b/packages/engine/debug/make-debug-pages.ts
@@ -43,7 +43,8 @@ function createPlayPagePromises(maps: Maps): Promise<void>[] {
             path.join(outputDirectory, `${params.outputPageName}.html`), params.html));
 }
 
-function createPlayPageConfig(mapData: string, cssName?: string, isClassicMode?: true): InputConfig {
+function createPlayPageConfig(mapDataName: string, cssName?: string, isClassicMode?: true): InputConfig {
+    const canIncludeUserVarOptions = (mapDataName === "wwamap");
     return {
         page: {
             additionalCssFiles: ["style.css"],
@@ -54,17 +55,21 @@ function createPlayPageConfig(mapData: string, cssName?: string, isClassicMode?:
                 autoSave: {
                     intervalSteps: 200
                 },
-                varDump: {
-                    elementId: "vardump"
-                },
-                isShowUserVariable: true
+                ... (canIncludeUserVarOptions ? {
+                    userVars: {
+                        dumpElementId: "vardump",
+                        canDisplay: true
+                    }
+                } : {})
             },
             resources: {
-                mapData: `${mapData}.dat`,
+                mapData: `${mapDataName}.dat`,
                 wwaJs: isDev ? "wwa.long.js" : "wwa.js",
                 wwaCss: cssName,
                 titleImage: "cover.gif",
-                userVarNamesFile: `${mapData}-vars.json`
+                ...(canIncludeUserVarOptions ? {
+                    userVarNamesFile: `${mapDataName}-vars.json`
+                } : {})
             },
         },
         copyrights: "official-and-wing"

--- a/packages/engine/src/wwa_data.ts
+++ b/packages/engine/src/wwa_data.ts
@@ -1010,3 +1010,12 @@ export enum IDTable {
  * equipment 装備品のみ
  */
 export type StatusSolutionKind = "all" | "bare" | "equipment";
+
+export type JsonRequestErrorKind = "brokenJson" | "httpError";
+
+export type UserVarNameListRequestErrorKind = JsonRequestErrorKind | "notObject" | "noFileSpecified";
+
+export type JsonRequestError<ErrorKind = JsonRequestErrorKind> = {
+    kind: ErrorKind;
+    detail: string;
+}

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -1052,9 +1052,10 @@ export class WWA {
             } else {
                 this._userVarNameListRequestError = {
                     kind: "noFileSpecified",
-                    detail: "data-wwa-user-var-names-file 属性が指定されませんでした。"
+                    detail: "data-wwa-user-var-names-file 属性に、変数の説明を記したファイル名を書くことで、その説明を表示できます。詳しくはマニュアルをご覧ください。"
                 }
-                this._updateVarDumpInformationArea(this._userVarNameListRequestError.detail, true);
+                // こういうこともできますよ、という案内なのでエラーにはしない
+                this._updateVarDumpInformationArea(this._userVarNameListRequestError.detail, false);
             }
         }
     }
@@ -4504,9 +4505,13 @@ export class WWA {
             this.setNowPlayTime();
             let helpMessage: string = '変数一覧\n';
             if (this._userVarNameListRequestError) {
-                helpMessage += "【変数名取得失敗】\n";
-                helpMessage += "  すべての変数を名無しとしています。\n";
-                helpMessage += `  エラー詳細: ${this._userVarNameListRequestError.detail}\n`
+                if (this._userVarNameListRequestError.kind === "noFileSpecified") {
+                    helpMessage += this._userVarNameListRequestError.detail + "\n";
+                } else {
+                    helpMessage += "【変数名取得失敗】\n";
+                    helpMessage += "  すべての変数を名無しとしています。\n";
+                    helpMessage += `  エラー詳細: ${this._userVarNameListRequestError.detail}\n`
+                }
             }
             for (let i = 0; i < Consts.INLINE_USER_VAR_VIEWER_DISPLAY_NUM; i++) {
                 /** 終端まで行った際にはループして0番目から参照する */

--- a/packages/page-generator/src/data-types/wwa.ts
+++ b/packages/page-generator/src/data-types/wwa.ts
@@ -7,10 +7,10 @@ export interface GameOption {
         intervalSteps: number;
     };
     useLookingAround?: boolean;
-    varDump?: {
-        elementId: string
-    };
-    isShowUserVariable?: boolean;
+    userVars?: {
+        dumpElementId: string
+        canDisplay?: boolean
+    }
 }
 
 export interface Resources {

--- a/packages/page-generator/src/index.ts
+++ b/packages/page-generator/src/index.ts
@@ -65,12 +65,12 @@ function generateTemplateValues({page, wwa, copyrights}: InputConfig): TemplateV
                 "data-wwa-looking-around": Helper.toStringBooleanOptional(wwa.gameOption?.useLookingAround),
                 "data-wwa-autosave": `${wwa.gameOption?.autoSave?.intervalSteps ?? "0"}`,
                 "data-wwa-resume-savedata": wwa.resumeSaveData,
-                "data-wwa-var-dump-elm": wwa.gameOption?.varDump?.elementId ? `#${wwa.gameOption.varDump.elementId}` : undefined,
+                "data-wwa-var-dump-elm": wwa.gameOption?.userVars?.dumpElementId ? `#${wwa.gameOption.userVars.dumpElementId}` : undefined,
                 "data-wwa-user-var-names-file": wwa.resources.userVarNamesFile,
-                "data-wwa-display-user-vars": Helper.toStringBooleanOptional(wwa.gameOption?.isShowUserVariable)
+                "data-wwa-display-user-vars": Helper.toStringBooleanOptional(wwa.gameOption?.userVars?.canDisplay)
             }
         },
-        varDumpElement: wwa.gameOption?.varDump?.elementId ? { id: wwa.gameOption.varDump.elementId } : undefined,
+        varDumpElement: wwa.gameOption?.userVars?.dumpElementId ? { id: wwa.gameOption.userVars.dumpElementId } : undefined,
         footer: {
             copyrights: Helper.generateCopyrights(copyrights)
         }

--- a/packages/styles/src/core/_vardump.scss
+++ b/packages/styles/src/core/_vardump.scss
@@ -14,6 +14,28 @@
 
 .wwa-vardump-wrapper>table tr.var-number>th {
   background-color: #FFFF66;
+  position: relative;
+  &[data-labelled-var-index="true"] {
+    font-weight: bold;
+    text-decoration: underline;
+    background-color: #66FFFF;
+    cursor: pointer;
+  }
+  & > div {
+    cursor: auto;
+    position: absolute;
+    top: 15px;
+    left: 45px;
+    display: block;
+    width: max-content;
+    background-color: #000000;
+    color: #FFFFFF;
+    z-index: 100;
+    padding: 5px;
+    &[aria-hidden="true"] {
+      display: none;
+    }
+  }
 }
 
 .wwa-vardump-wrapper>table tr.var-val>td {

--- a/packages/styles/src/core/_vardump.scss
+++ b/packages/styles/src/core/_vardump.scss
@@ -38,7 +38,8 @@
   }
 }
 
-.wwa-vardump-wrapper>table tr.var-val>td {
+.wwa-vardump-wrapper>table tr.var-val>td,
+.wwa-vardump-wrapper>table>td.varlist-information {
   background-color: #FFFFCC;
 }
 


### PR DESCRIPTION
- 旧来のtableでの変数一覧表示で、添字をマウスホバーで説明を表示できるようにします
- 変数一覧ファイルの取得に失敗した場合にエラー表示します
- 整合性の関係で、スタンダードマップ以外では変数一覧を非表示にします