### PR TITLE
fix: pkg のバージョンと扱う Node のバージョンを変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8847,9 +8847,9 @@
       }
     },
     "node_modules/pkg": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.5.2.tgz",
-      "integrity": "sha512-pD0UB2ud01C6pVv2wpGsTYJrXI/bnvGRYvMLd44wFzA1p+A2jrlTGFPAYa7YEYzmitXhx23PqalaG1eUEnSwcA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.6.0.tgz",
+      "integrity": "sha512-mHrAVSQWmHA41RnUmRpC7pK9lNnMfdA16CF3cqOI22a8LZxOQzF7M8YWtA2nfs+d7I0MTDXOtkDsAsFXeCpYjg==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "7.16.2",
@@ -8861,7 +8861,7 @@
         "into-stream": "^6.0.0",
         "minimist": "^1.2.5",
         "multistream": "^4.1.0",
-        "pkg-fetch": "3.2.6",
+        "pkg-fetch": "3.3.0",
         "prebuild-install": "6.1.4",
         "progress": "^2.0.3",
         "resolve": "^1.20.0",
@@ -8892,9 +8892,9 @@
       }
     },
     "node_modules/pkg-fetch": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.2.6.tgz",
-      "integrity": "sha512-Q8fx6SIT022g0cdSE4Axv/xpfHeltspo2gg1KsWRinLQZOTRRAtOOaEFghA1F3jJ8FVsh8hGrL/Pb6Ea5XHIFw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.3.0.tgz",
+      "integrity": "sha512-xJnIZ1KP+8rNN+VLafwu4tEeV4m8IkFBDdCFqmAJz9K1aiXEtbARmdbEe6HlXWGSVuShSHjFXpfkKRkDBQ5kiA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -12586,7 +12586,7 @@
         "@types/express": "4.17.11",
         "@types/node": "^12.12.6",
         "express": "^4.17.1",
-        "pkg": "^5.5.1",
+        "pkg": "^5.6.0",
         "shelljs": "^0.8.4",
         "shx": "^0.3.3",
         "typescript": "^4.5.4"
@@ -14374,7 +14374,7 @@
         "@types/express": "4.17.11",
         "@types/node": "^12.12.6",
         "express": "^4.17.1",
-        "pkg": "^5.5.1",
+        "pkg": "^5.6.0",
         "shelljs": "^0.8.4",
         "shx": "^0.3.3",
         "typescript": "^4.5.4"
@@ -18763,9 +18763,9 @@
       "dev": true
     },
     "pkg": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.5.2.tgz",
-      "integrity": "sha512-pD0UB2ud01C6pVv2wpGsTYJrXI/bnvGRYvMLd44wFzA1p+A2jrlTGFPAYa7YEYzmitXhx23PqalaG1eUEnSwcA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.6.0.tgz",
+      "integrity": "sha512-mHrAVSQWmHA41RnUmRpC7pK9lNnMfdA16CF3cqOI22a8LZxOQzF7M8YWtA2nfs+d7I0MTDXOtkDsAsFXeCpYjg==",
       "dev": true,
       "requires": {
         "@babel/parser": "7.16.2",
@@ -18777,7 +18777,7 @@
         "into-stream": "^6.0.0",
         "minimist": "^1.2.5",
         "multistream": "^4.1.0",
-        "pkg-fetch": "3.2.6",
+        "pkg-fetch": "3.3.0",
         "prebuild-install": "6.1.4",
         "progress": "^2.0.3",
         "resolve": "^1.20.0",
@@ -18903,9 +18903,9 @@
       }
     },
     "pkg-fetch": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.2.6.tgz",
-      "integrity": "sha512-Q8fx6SIT022g0cdSE4Axv/xpfHeltspo2gg1KsWRinLQZOTRRAtOOaEFghA1F3jJ8FVsh8hGrL/Pb6Ea5XHIFw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.3.0.tgz",
+      "integrity": "sha512-xJnIZ1KP+8rNN+VLafwu4tEeV4m8IkFBDdCFqmAJz9K1aiXEtbARmdbEe6HlXWGSVuShSHjFXpfkKRkDBQ5kiA==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",

--- a/packages/debug-server/package.json
+++ b/packages/debug-server/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "npm run build && node lib debug",
     "build": "tsc -p .",
-    "generate": "shx mkdir -p bin && pkg -t node16.13.2-win-x64 ./lib/index.js --output bin/wwa-server.exe",
+    "generate": "shx mkdir -p bin && pkg -t node16-win-x64 ./lib/index.js --output bin/wwa-server.exe",
     "clean": "shx rm -rf debug lib bin",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -20,7 +20,7 @@
     "@types/express": "4.17.11",
     "@types/node": "^12.12.6",
     "express": "^4.17.1",
-    "pkg": "^5.5.1",
+    "pkg": "^5.6.0",
     "shelljs": "^0.8.4",
     "shx": "^0.3.3",
     "typescript": "^4.5.4"


### PR DESCRIPTION
pkg で指定している 16.13.2 のバージョンが存在しないようで、 GitHub Actions の Publish で落ちてしまうようなので、取り出す Node のバージョンを 16 に変更しました。
また、発生する pkg のバージョンは 5.6.0 なので pkg のバージョンも変更しています。