### PR TITLE
コピーボタンの機能追加

### DIFF
--- a/packages/engine/src/wwa_password_window.ts
+++ b/packages/engine/src/wwa_password_window.ts
@@ -20,6 +20,7 @@ const DESCRIPTION_SAVE = (
 );
 
 export class PasswordWindow {
+    private readonly COPIED_MESSAGE_DISPLAY_MS = 1000;
     private _element: HTMLDivElement;
     private _okButtonElement: HTMLButtonElement;
     private _cancelButtonElement: HTMLButtonElement;
@@ -62,8 +63,16 @@ export class PasswordWindow {
 
         this._copyButtonElement = document.createElement("button");
         this._copyButtonElement.textContent = "コピー";
-        this._copyButtonElement.addEventListener("click", () => {
-            navigator.clipboard.writeText(this.password);
+        this._copyButtonElement.addEventListener("click", async () => {
+            await navigator.clipboard.writeText(this.password);
+            this._copyButtonElement.textContent = "コピーしました";
+            this._copyButtonElement.disabled = true;
+            setTimeout(() => {
+                if (this._copyButtonElement) {
+                    this._copyButtonElement.textContent = "コピー";
+                    this._copyButtonElement.disabled = false;
+                }
+            }, this.COPIED_MESSAGE_DISPLAY_MS);
         });
 
         this._buttonWrapperElement.appendChild(this._okButtonElement);

--- a/packages/engine/src/wwa_password_window.ts
+++ b/packages/engine/src/wwa_password_window.ts
@@ -23,6 +23,7 @@ export class PasswordWindow {
     private _element: HTMLDivElement;
     private _okButtonElement: HTMLButtonElement;
     private _cancelButtonElement: HTMLButtonElement;
+    private _copyButtonElement: HTMLButtonElement;
     private _descriptionElement: HTMLDivElement;
     private _passwordBoxElement: HTMLTextAreaElement;
     private _buttonWrapperElement: HTMLDivElement;
@@ -59,8 +60,15 @@ export class PasswordWindow {
             this._wwa.hidePasswordWindow(true);
         });
 
+        this._copyButtonElement = document.createElement("button");
+        this._copyButtonElement.textContent = "コピー";
+        this._copyButtonElement.addEventListener("click", () => {
+            navigator.clipboard.writeText(this.password);
+        });
+
         this._buttonWrapperElement.appendChild(this._okButtonElement);
         this._buttonWrapperElement.appendChild(this._cancelButtonElement);
+        this._buttonWrapperElement.appendChild(this._copyButtonElement);
         this._mode = Mode.LOAD;
 
         this._element.appendChild(this._descriptionElement);
@@ -109,10 +117,12 @@ export class PasswordWindow {
                 this._passwordBoxElement.removeAttribute("readonly");
             } catch (e) { }
             this._cancelButtonElement.style.display = "inline";
+            this._copyButtonElement.style.display = "none";
         } else {
             msg = DESCRIPTION_SAVE;
             this._passwordBoxElement.setAttribute("readonly", "readonly");
             this._cancelButtonElement.style.display = "none";
+            this._copyButtonElement.style.display = "inline";
         }
         var mesArray = msg.split("\n");
         this._descriptionElement.textContent = "";


### PR DESCRIPTION

https://user-images.githubusercontent.com/12381375/175762846-d1587830-e1f9-4c70-9c4b-962caaae62fe.mov

- Close: #275 

## 仕様
- パスワードセーブの画面に「コピー」ボタンを追加します。
- 「コピー」ボタンを押すと「コピーしました」にテキストが代わり、１秒後にもとに戻ります。