### PR TITLE
chore: デバッグサーバーで index からファイル一覧を表示できるようにする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4777,6 +4777,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/serve-static": {
       "version": "1.13.10",
       "dev": true,
@@ -5678,6 +5687,12 @@
       "version": "5.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
+      "dev": true
     },
     "node_modules/before-after-hook": {
       "version": "2.2.2",
@@ -18059,6 +18074,84 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-index/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/serve-index/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-index/node_modules/http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+      "dev": true,
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-index/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true
+    },
+    "node_modules/serve-index/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/serve-index/node_modules/setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
+    },
+    "node_modules/serve-index/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/serve-static": {
       "version": "1.15.0",
       "dev": true,
@@ -20524,8 +20617,10 @@
       "devDependencies": {
         "@types/express": "4.17.14",
         "@types/node": "^18.11.9",
+        "@types/serve-index": "1.9.1",
         "express": "^4.18.1",
         "pkg": "^5.8.0",
+        "serve-index": "1.9.1",
         "shelljs": "^0.8.5",
         "shx": "^0.3.4",
         "typescript": "^5.0.4"
@@ -24257,6 +24352,15 @@
         "@types/node": "*"
       }
     },
+    "@types/serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/serve-static": {
       "version": "1.13.10",
       "dev": true,
@@ -24518,8 +24622,10 @@
       "requires": {
         "@types/express": "4.17.14",
         "@types/node": "^18.11.9",
+        "@types/serve-index": "1.9.1",
         "express": "^4.18.1",
         "pkg": "^5.8.0",
+        "serve-index": "1.9.1",
         "shelljs": "^0.8.5",
         "shx": "^0.3.4",
         "typescript": "^5.0.4"
@@ -25069,6 +25175,12 @@
           "dev": true
         }
       }
+    },
+    "batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
+      "dev": true
     },
     "before-after-hook": {
       "version": "2.2.2",
@@ -34113,6 +34225,74 @@
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+          "dev": true
+        }
       }
     },
     "serve-static": {

--- a/packages/debug-server/package.json
+++ b/packages/debug-server/package.json
@@ -19,8 +19,10 @@
   "devDependencies": {
     "@types/express": "4.17.14",
     "@types/node": "^18.11.9",
+    "@types/serve-index": "1.9.1",
     "express": "^4.18.1",
     "pkg": "^5.8.0",
+    "serve-index": "1.9.1",
     "shelljs": "^0.8.5",
     "shx": "^0.3.4",
     "typescript": "^5.0.4"

--- a/packages/debug-server/src/index.ts
+++ b/packages/debug-server/src/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import serveIndex from "serve-index";
 
 const baseDir = process.argv.length < 3 ? "." : process.argv[2];
 
@@ -17,7 +18,10 @@ function parseServerPort(port: string | undefined): number {
 
 const app = express();
 const SERVER_PORT = parseServerPort(process.env.WWA_SERVER_PORT);
-app.use("/", express.static(baseDir));
+app.use("/",
+    express.static(baseDir),
+    serveIndex(baseDir, { icons: true })
+);
 app.listen(SERVER_PORT, () =>  {
     console.log("Welcome to WWA Server!");
     console.log(`http://localhost:${SERVER_PORT} でローカルでマップの仕上がりを確認できます。`);

--- a/packages/engine/debug/make-debug-pages.ts
+++ b/packages/engine/debug/make-debug-pages.ts
@@ -1,6 +1,5 @@
 import { render, InputConfig } from "@wwawing/page-generator";
 import * as fs from "fs";
-import * as pug from "pug";
 import * as path from "path";
 import maps from "./maps-config";
 
@@ -14,23 +13,13 @@ interface IndexPageOption {
     }
 }
 
-const indexPageTemplageFile = path.join(__dirname, "index.pug");
-const compileIndexPage = pug.compileFile(indexPageTemplageFile, { pretty: true });
 const outputDirectory = path.join(__dirname, "..", "lib");
 
-Promise.all([
-    ...createPlayPagePromises(maps),
-    createIndexPage({ page: { maps, thisYear: new Date().getFullYear() } })
-])
+Promise.all(createPlayPagePromises(maps))
     .catch(error => {
         console.error("error", error);
         process.exit(1);
     });
-
-function createIndexPage(option: IndexPageOption): Promise<void> {
-    return createWriteFilePromise(
-        path.join(outputDirectory, "index.html"), `${compileIndexPage(option)}\n`);
-}
 
 function createPlayPagePromises(maps: Maps): Promise<void>[] {
     return maps


### PR DESCRIPTION
# 経緯
制作中の WWA は debug-server を起動して動かしたい WWA ゲームの HTML ファイルを URL から探すのですが、
ディレクトリ構造を頭に入れて localhost:3000/mapdata/example/wwamap.html ... と入力するのは大変です。
ブラウザーの履歴が残っていれば、そこからアクセスすることは容易ですが、初めてテストプレイを行う場合だと、初心者にとっては苦痛のように思います。

# 機能
![wwa_dev_server_serve_index](https://github.com/WWAWing/WWAWing/assets/12381375/2e5e6c16-27c5-483e-83f1-873379381619)

Node.js では、ディレクトリの index からファイル一覧を表示できる serve-index パッケージがあるため、これを利用してディレクトリ一覧を表示するようにしました。
serve-index ではファイルまたはディレクトリのフィルタリングができますが、ファイルかディレクトリか識別することは困難なため、今のところフィルタリングなしで動かしています。

また、これに伴い、 `@wwawing/engine` の WWA 一覧ページのデプロイ処理を削除しました。
（`index.html` から別のファイル名にして復活する方法もあるかもしれません。）