### PR TITLE
feat(sound): soundマクロでBGM遅延再生に対応

### DIFF
--- a/packages/engine/src/wwa_message.ts
+++ b/packages/engine/src/wwa_message.ts
@@ -1108,11 +1108,12 @@ export class Macro {
     }
 
     private _executeSoundMacro(): void {
-        this._concatEmptyArgs(1);
+        this._concatEmptyArgs(2);
         // 注) $sound マクロは、マップデータ読み込み時に全メッセージ解析でロードする音源を決定しているため
         // 変数などによるサウンド番号指定を受け付けない
-        var id = parseInt(this.macroArgs[0]);
-        this._wwa.playSound(id);
+        const id = parseInt(this.macroArgs[0]);
+        const bgmDelayMs = parseInt(this.macroArgs[1]);
+        this._wwa.playSound(id, bgmDelayMs);
     }
     private _executeGamePadButtonMacro(): void {
         this._concatEmptyArgs(2);


### PR DESCRIPTION
$delay_sound とよく似ていますが、こちらは結果を保存せず、その実行でのみ再生を遅延させます。