### PR TITLE
fix(system-message): システムメッセージのデフォルト値が適用されない不具合を修正

### DIFF
--- a/packages/common-interface/src/wwa_system_message.ts
+++ b/packages/common-interface/src/wwa_system_message.ts
@@ -10,7 +10,11 @@ export interface Config {
 const _systemMessage = Object.freeze({
   CONFIRM_LOAD_SOUND: {
     code: 1,
-    defaultText: "効果音・ＢＧＭデータをロードしますか？"
+    defaultText: "効果音・ＢＧＭデータをロードしますか？",
+    mapdataParams: {
+      messageArea:"systemMessage",
+      index: 2
+    }
   },
   NO_MONEY: {
     code: 101,
@@ -40,14 +44,18 @@ const _systemMessage = Object.freeze({
     code: 203,
     defaultText: `このアイテムは%HOW_TO_USE_ITEM%ことで使用できます。
 使用できるアイテムは色枠で囲まれます。`,
+    mapdataParams: {
+       messageArea: "systemMessage",
+      index: 0,
+    }
   },
   CONFIRM_USE_ITEM: {
     code: 204,
     defaultText: `このアイテムを使用します。
 よろしいですか?`,
     mapdataParams: {
-      messageArea: "systemMessage",
-      index: 0,
+      messageArea: "message",
+      index: 8,
     },
   },
   CANNOT_DAMAGE_MONSTER: {
@@ -58,6 +66,10 @@ const _systemMessage = Object.freeze({
     code: 401,
     defaultText: `他のページにリンクします。
 よろしいですか？`,
+    mapdataParams: {
+        messageArea: "message",
+        index: 5
+    }
   },
   GAME_SPEED_CHANGED: {
     code: 501,
@@ -70,11 +82,12 @@ const _systemMessage = Object.freeze({
     defaultText: `ここでは移動速度を
 変更できません。`,
   },
-} as const);
+} as {[key in string]: Config});
 
 export const keys = Object.keys(_systemMessage) as Key[];
 
-export type Key = keyof typeof _systemMessage;
+// string と交差させないと keyof で number が乱入してくる
+export type Key = (keyof typeof _systemMessage) & string;
 export const Key = (
     keys
 ).reduce<Partial<{ [KEY in Key]: Key }>>(

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -6158,10 +6158,12 @@ font-weight: bold;
     }
 
     private _loadSystemMessage(key: SystemMessage.Key): string {
+        // マクロなどで上書きされたシステムメッセージを解決
         if (this._wwaData.customSystemMessages[key]) {
             return this._wwaData.customSystemMessages[key];
         }
         const config = SystemMessage.ConfigMap[key];
+        // マップデータで定義されたシステムメッセージがあればそれを使う、さもなくばWWAデフォルトのメッセージを使用する
         if (config.mapdataParams) {
             switch (config.mapdataParams.messageArea) {
                 case "message": {


### PR DESCRIPTION
以下のシステムメッセージに対してデフォルト値（ON, OFF, DEFAULTの設定含む）が適用されていなかったので修正します。

- `CONFIRM_LOAD_SOUND` (効果音・ＢＧＭデータをロードしますか？)
- `ITEM_SELECT_TUTORIAL` (このアイテムは%HOW_TO_USE_ITEM%ことで使用できます。使用できるアイテムは色枠で囲まれます)
- `CONFIRM_ENTER_URL_GATE` (他のページにリンクします。よろしいですか？)

また、アイテム使用メッセージが出るべきところでアイテム使用可能メッセージが表示されることがあったので修正します。