### PR TITLE
fix(play-time): 経過時間が正しく表示されない不具合を修正・リファクタ

### DIFF
--- a/packages/engine/src/wwa_parts_player.ts
+++ b/packages/engine/src/wwa_parts_player.ts
@@ -88,6 +88,7 @@ export class Player extends PartsObject {
 
     protected _enemy: Monster;
     protected _moves: number;
+    // 現状使われていないに等しいが、セーブデータに互換性のため入っている。
     protected _frameCount: number;
 
     protected _moveMacroWaitingRemainMoves: number;
@@ -1098,18 +1099,6 @@ export class Player extends PartsObject {
         return new Coord(targetX, targetY);
     }
 
-    /**
-     * ゲーム開始から経過したフレーム数を基に、 HHHH:MM:SS 形式のプレイ時間文字列を返します。
-     */
-    public getPlayTimeText(): string {
-        const seconds = Math.floor(this._frameCount / 60);
-        // FIY: 0とのビットOR( | ) は 小数点以下切り捨て
-        return seconds >= 60 * 60 * 10000 ?
-            "9999:99:99" :
-            ("000" + ((seconds / 60 / 60) | 0)).slice(-4) +
-            ":" + ("0" + (((seconds / 60) | 0) % 60)).slice(-2) +
-            ":" + ("0" + (seconds % 60)).slice(-2);
-    }
 
     //プレイ時間を計測
     public mainFrameCount(): void {
@@ -1225,7 +1214,6 @@ export class Player extends PartsObject {
         this._isReadyToUseItem = false;
         this._isClickableItemGot = false;
         this._moves = moves;
-        this._frameCount = 0;
         this._moveMacroWaitingRemainMoves = 0;
         this._moveObjectAutoExecTimer = 0;
         this.updateStatusValueBox();

--- a/packages/engine/src/wwa_play_time.ts
+++ b/packages/engine/src/wwa_play_time.ts
@@ -1,0 +1,60 @@
+/**
+ * プレイ時間を計算してくれるやつ
+ * ロードやTIME代入などを実施する場合はインスタンスを作り直してください。
+ */
+export class PlayTimeCalculator {
+    /**
+     * 最後にプレイ時間を計算した時刻
+     */
+    private lastCalculatedTimeUnixMs: number;
+
+    /**
+     * 最後に計算されたプレイ時間
+     */
+    private lastCalculatedPlayTimeMs: number;
+
+    /**
+     * @param baseTimeMs プレイ時間の初期値。この時間からカウントされます。
+     */
+    constructor(baseTimeMs: number = 0) {
+        this.lastCalculatedTimeUnixMs = Date.now();
+        this.lastCalculatedPlayTimeMs = baseTimeMs;
+    }
+
+    /**
+     * プレイ時間を計算して返します。
+     * @returns プレイ時間
+     */
+    public calculateTimeMs(): number {
+        const now = Date.now();
+        // 前回計算が走った時刻から現在までの時間を、前回計算した時刻を加算するとプレイ時間になる
+        const newPlayTime = now - this.lastCalculatedTimeUnixMs + this.lastCalculatedPlayTimeMs;
+        this.lastCalculatedTimeUnixMs = now;
+        this.lastCalculatedPlayTimeMs = newPlayTime;
+        return newPlayTime;
+    }
+
+    /**
+     * HHHH:MM:SS 形式のプレイ時間文字列を計算して返します。
+     */
+    public calculatePlayTimeFormat(): string {
+        return PlayTimeCalculator.formatPlayTimeText(
+          this.calculateTimeMs() / 1000
+        );
+   }
+
+    /**
+     * HHHH:MM:SS 形式のプレイ時間文字列を返します。
+     * @param 変換する時間（秒）
+     */
+    public static formatPlayTimeText(timeSec: number): string {
+        const flooredSec = Math.floor(timeSec);
+        // FIY: 0とのビットOR( | ) は 小数点以下切り捨て
+        return flooredSec >= 60 * 60 * 10000 ?
+            "9999:99:99" :
+            ("000" + ((flooredSec / 60 / 60) | 0)).slice(-4) +
+            ":" + ("0" + (((flooredSec / 60) | 0) % 60)).slice(-2) +
+            ":" + ("0" + (flooredSec % 60)).slice(-2);
+    }
+
+}


### PR DESCRIPTION
- 経過時間がゲーム起動時からのフレームカウントになっており、セーブデータと連動していなかったため、TIMEと同等の時間を使うように変更します。
  - 本来はフレームカウントを利用したほうがよかったかもしれませんが、TIMEがDateの引き算で実装されている関係で、そちらに統一させていただきます。
- TIMEの計算が複雑化していたのでクラスに機能を集約するリファクタを実施しました。