### PR TITLE
ダメージ方程式をユーザカスタム関数でカスタマイズできるようにしました

### DIFF
--- a/packages/assets/script/defined.js
+++ b/packages/assets/script/defined.js
@@ -99,3 +99,13 @@ function CALL_CHANGE_SPEED() {
 function CALL_JUMPGATE() {
   MSG("jumpgate移動しました")
 }
+
+function CALC_PLAYER_TO_ENEMY_DAMAGE() {
+  // ENEMY_HP / ENEMY_AT / ENEMY_DF
+  MONEY += 1;
+}
+
+function CALC_ENEMY_TO_PLAYER_DAMAGE() {
+  // ENEMY_HP / ENEMY_AT / ENEMY_DF
+  v[0] += 1;
+}

--- a/packages/assets/script/defined.js
+++ b/packages/assets/script/defined.js
@@ -100,12 +100,22 @@ function CALL_JUMPGATE() {
   MSG("jumpgate移動しました")
 }
 
+/**
+ * プレイヤーから敵に与えるダメージ計算式
+ */
 function CALC_PLAYER_TO_ENEMY_DAMAGE() {
-  // ENEMY_HP / ENEMY_AT / ENEMY_DF
-  MONEY += 1;
+  v["tmp_enemy_damage"] = (AT - ENEMY_DF)
+  if(v["tmp_enemy_damage"] > 0) {
+    ENEMY_HP = ENEMY_HP - v["tmp_enemy_damage"];
+  }
 }
 
+/**
+ * 敵からプレイヤーに与えるダメージ計算式
+ */
 function CALC_ENEMY_TO_PLAYER_DAMAGE() {
-  // ENEMY_HP / ENEMY_AT / ENEMY_DF
-  v[0] += 1;
+  v["tmp_player_damage"] = (ENEMY_AT - DF)
+  if(v["tmp_player_damage"] > 0) {
+    HP = HP - v["tmp_player_damage"];
+  }
 }

--- a/packages/common-interface/src/wwa_system_message.ts
+++ b/packages/common-interface/src/wwa_system_message.ts
@@ -60,7 +60,7 @@ const _systemMessage = Object.freeze({
   },
   CANNOT_DAMAGE_MONSTER: {
     code: 301,
-    defaultText: "相手の防御能力が高すぎる！",
+    defaultText: "勝負がつかない！",
   },
   CONFIRM_ENTER_URL_GATE: {
     code: 401,

--- a/packages/engine/src/wwa_data.ts
+++ b/packages/engine/src/wwa_data.ts
@@ -6,8 +6,8 @@ import type { JsonResponseErrorKind } from "./json_api_client";
 export { type WWAData };
 
 export class EquipmentStatus {
-    public strength: number;
-    public defence: number;
+    public strength: number | null;
+    public defence: number | null;
     public add(s: EquipmentStatus): EquipmentStatus {
         this.strength += s.strength;
         this.defence += s.defence;
@@ -28,7 +28,7 @@ export class EquipmentStatus {
     public equals(e: EquipmentStatus): boolean {
         return this.strength === e.strength && this.defence === e.defence;
     }
-    public constructor(s: number, d: number) {
+    public constructor(s: number | null, d: number | null) {
         this.strength = s;
         this.defence = d;
     }
@@ -37,7 +37,7 @@ export class EquipmentStatus {
 
 
 export class Status extends EquipmentStatus {
-    public energy: number;
+    public energy: number | null;
     public gold: number;
 
     public add(s: EquipmentStatus): Status {
@@ -88,7 +88,7 @@ export class Status extends EquipmentStatus {
         return (Object.keys(scoreOption.rates) as Key[]).reduce((prev, key) =>  prev + scoreOption.rates[key] * this[key], 0);
     }
 
-    public constructor( e: number, s: number, d: number, g: number) {
+    public constructor(e: number | null, s: number | null, d: number | null, g: number) {
         super(s, d);
         this.energy = e;
         this.gold = g;

--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -444,6 +444,9 @@ function convertIdentifer(node: Acorn.Identifier): Wwa.Symbol | Wwa.Literal {
     case "LOOPLIMIT":
     case "ITEM_ID":
     case "ITEM_POS":
+    case "ENEMY_HP":
+    case "ENEMY_AT":
+    case "ENEMY_DF":
       return {
         type: "Symbol",
         name: node.name

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -697,36 +697,37 @@ export class EvalCalcWwaNode {
   }
 
   evalSymbol(node: Wwa.Symbol) {
-    const game_status = this.generator.wwa.getGameStatus();
+    const gameStatus = this.generator.wwa.getGameStatus();
+    const enemyStatus = this.generator.wwa.getEnemyStatus();
     switch(node.name) {
       case "X":
       case "Y":
         // UNDONE: WWAから値を取得する
         return 0;
       case "PX":
-        return game_status.playerCoord.x;
+        return gameStatus.playerCoord.x;
       case "PY":
-        return game_status.playerCoord.y;
+        return gameStatus.playerCoord.y;
       case "AT":
-        return game_status.bareStatus.strength;
+        return gameStatus.bareStatus.strength;
       case "AT_TOTAL":
-        return game_status.totalStatus.strength;
+        return gameStatus.totalStatus.strength;
       case "DF":
-        return game_status.bareStatus.defence;
+        return gameStatus.bareStatus.defence;
       case "DF_TOTAL":
-        return game_status.totalStatus.defence;
+        return gameStatus.totalStatus.defence;
       case "GD":      
-        return game_status.totalStatus.gold;
+        return gameStatus.totalStatus.gold;
       case "HP":      
-        return game_status.totalStatus.energy;
+        return gameStatus.totalStatus.energy;
       case "HPMAX":
-        return game_status.energyMax;
+        return gameStatus.energyMax;
       case "STEP":
-        return game_status.moveCount;
+        return gameStatus.moveCount;
       case "TIME":
-        return game_status.playTime;
+        return gameStatus.playTime;
       case "PDIR":
-        return game_status.playerDirection
+        return gameStatus.playerDirection
       /** for文用（暫定） */
       case 'i':
         return this.for_id.i;
@@ -740,6 +741,12 @@ export class EvalCalcWwaNode {
         return this.generator.readonly_value.item_id;
       case 'ITEM_POS':
         return this.generator.readonly_value.item_pos;
+      case 'ENEMY_HP':
+        return typeof enemyStatus === 'number'? -1: enemyStatus.energy;
+      case 'ENEMY_AT':
+        return typeof enemyStatus === 'number'? -1: enemyStatus.strength;
+      case 'ENEMY_DF':
+        return typeof enemyStatus === 'number'? -1: enemyStatus.defence;
       default:
         throw new Error("このシンボルは取得できません")
     }

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -1,5 +1,5 @@
 import { SystemMessage } from "@wwawing/common-interface";
-import { Coord, MacroStatusIndex, PartsType } from "../wwa_data";
+import { Coord, MacroStatusIndex, PartsType, Status } from "../wwa_data";
 import { WWA } from "../wwa_main";
 import * as Wwa from "./wwa";
 
@@ -637,6 +637,21 @@ export class EvalCalcWwaNode {
         return 0;
       case 'LOOPLIMIT':
         this.generator.updateLoopLimit(this.evalWwaNode(node.value));
+        return 0;
+      case 'ENEMY_HP':
+        this.generator.wwa.setEnemyStatus(
+          new Status(this.evalWwaNode(node.value), 0, 0, 0)
+        );
+        return 0;
+      case 'ENEMY_AT':
+        this.generator.wwa.setEnemyStatus(
+          new Status(0, this.evalWwaNode(node.value), 0, 0)
+        );
+        return 0;
+      case 'ENEMY_DF':
+        this.generator.wwa.setEnemyStatus(
+          new Status(0, 0, this.evalWwaNode(node.value), 0)
+        );
         return 0;
       default:
         console.error("未実装の要素です: "+node.kind);

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -640,17 +640,17 @@ export class EvalCalcWwaNode {
         return 0;
       case 'ENEMY_HP':
         this.generator.wwa.setEnemyStatus(
-          new Status(this.evalWwaNode(node.value), 0, 0, 0)
+          new Status(this.evalWwaNode(node.value), null, null, 0)
         );
         return 0;
       case 'ENEMY_AT':
         this.generator.wwa.setEnemyStatus(
-          new Status(0, this.evalWwaNode(node.value), 0, 0)
+          new Status(null, this.evalWwaNode(node.value), null, 0)
         );
         return 0;
       case 'ENEMY_DF':
         this.generator.wwa.setEnemyStatus(
-          new Status(0, 0, this.evalWwaNode(node.value), 0)
+          new Status(null, null, this.evalWwaNode(node.value), 0)
         );
         return 0;
       default:

--- a/packages/engine/src/wwa_expression2/wwa.ts
+++ b/packages/engine/src/wwa_expression2/wwa.ts
@@ -30,7 +30,7 @@ export interface UserVariableAssignment {
 
 export interface SpecialParameterAssignment {
   type: "SpecialParameterAssignment";
-  kind: "X" | "Y" | "PX" | "PY" | "HP" | "HPMAX" | "AT" | "DF" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS";
+  kind: "X" | "Y" | "PX" | "PY" | "HP" | "HPMAX" | "AT" | "DF" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF";
   value: Calcurable;
   operator?: "=" | "+=" | "-=" | "*=" | "/=";
 }
@@ -50,7 +50,7 @@ export interface BinaryOperation {
 
 export interface Symbol {
   type: "Symbol";
-  name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "PX" | "PY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS";
+  name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "PX" | "PY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF";
 }
 
 export interface Array1D {

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -6862,6 +6862,15 @@ font-weight: bold;
         return this._monster.status;
     }
 
+    public setEnemyStatus(status: Status) {
+        if(this._monster) {
+            this._monster.setStatus(status);
+        }
+        else {
+            throw new Error("敵が存在しません");
+        }
+    } 
+
     // TODO: 適切な場所に移す
     public getGameStatus() {
         return {

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -6855,6 +6855,13 @@ font-weight: bold;
         }
     }
 
+    public getEnemyStatus(): Status | number {
+        if(!this._monster) {
+            return -1;
+        }
+        return this._monster.status;
+    }
+
     // TODO: 適切な場所に移す
     public getGameStatus() {
         return {

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -1238,7 +1238,6 @@ export class WWA {
      * @returns ユーザ独自関数が定義されているか？
      */
     public callCalcEnemyToPlayerUserDefineFunction(): boolean {
-        console.log("hoge");
         const calcEnemyToPlayerFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALC_ENEMY_TO_PLAYER_DAMAGE"];
         if( calcEnemyToPlayerFunc ) {
             this.evalCalcWwaNodeGenerator.evalWwaNode(calcEnemyToPlayerFunc);

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -1220,6 +1220,33 @@ export class WWA {
         }
     }
 
+    /**
+     * 戦闘でPlayerToEnemyのダメージ発生時のユーザ定義独自関数を呼び出す
+     * @returns ユーザ独自関数が定義されているか？
+     **/
+    public callCalcPlayerToEnemyUserDefineFunction(): boolean {
+        const calcPlayerToEnemyFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALC_PLAYER_TO_ENEMY_DAMAGE"];
+        if(calcPlayerToEnemyFunc) {
+            this.evalCalcWwaNodeGenerator.evalWwaNode(calcPlayerToEnemyFunc);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 戦闘でEnemyToPlayerのダメージ発生時のユーザ定義独自関数を呼び出す
+     * @returns ユーザ独自関数が定義されているか？
+     */
+    public callCalcEnemyToPlayerUserDefineFunction(): boolean {
+        console.log("hoge");
+        const calcEnemyToPlayerFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALC_ENEMY_TO_PLAYER_DAMAGE"];
+        if( calcEnemyToPlayerFunc ) {
+            this.evalCalcWwaNodeGenerator.evalWwaNode(calcEnemyToPlayerFunc);
+            return true;
+        }
+        return false;
+    }
+
     /** プレイヤーが動いた際のユーザ定義独自関数を呼び出す */
     public callMoveUserDefineFunction() {
         const moveFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALL_MOVE"];
@@ -3457,7 +3484,9 @@ export class WWA {
             () => {
                 this._monsterWindow.hide();
                 this._dispatchWindowClosedTimeRequests();
-            });
+            },
+            this.callCalcPlayerToEnemyUserDefineFunction.bind(this)
+        );
 
         this._player.startBattleWith(this._monster);
         //↓待ち時間の前にやるのはよくないので、戦闘開始時にやります。

--- a/packages/engine/src/wwa_monster.ts
+++ b/packages/engine/src/wwa_monster.ts
@@ -33,5 +33,16 @@ export class Monster {
         this._battleEndCallback();
     }
 
+    public setStatus(status: Status): void {
+        if(status.energy) {
+            this._status.energy = status.energy;
+        }
+        if(status.strength) {
+            this._status.strength = status.strength;
+        }
+        if(status.defence) {
+            this._status.defence = status.defence;
+        }
+    }
 }
 

--- a/packages/engine/src/wwa_monster.ts
+++ b/packages/engine/src/wwa_monster.ts
@@ -23,10 +23,9 @@ export class Monster {
 
     public damage(amount: number): void {
         // Playerから敵を攻撃した時に呼ばれるユーザ定義関数
-        this._calcCustomCalcDamageFunc();
-        // if( !this._calcCustomCalcDamageFunc() ) {
+        if( !this._calcCustomCalcDamageFunc() ) {
             this._status.energy = Math.max(0, this._status.energy - amount);
-        // }
+        }
     }
 
     public battleEndProcess(): void {
@@ -34,13 +33,13 @@ export class Monster {
     }
 
     public setStatus(status: Status): void {
-        if(status.energy) {
+        if(status.energy !== null) {
             this._status.energy = status.energy;
         }
-        if(status.strength) {
+        if(status.strength !== null) {
             this._status.strength = status.strength;
         }
-        if(status.defence) {
+        if(status.defence !== null) {
             this._status.defence = status.defence;
         }
     }

--- a/packages/engine/src/wwa_monster.ts
+++ b/packages/engine/src/wwa_monster.ts
@@ -8,7 +8,8 @@ export class Monster {
         private _status: Status,
         private _message: string,
         private _item: number,
-        private _battleEndCallback: () => void
+        private _battleEndCallback: () => void,
+        private _calcCustomCalcDamageFunc: () => boolean
     ) {
 
     }
@@ -21,7 +22,11 @@ export class Monster {
     get item(): number { return this._item; }
 
     public damage(amount: number): void {
-        this._status.energy = Math.max(0, this._status.energy - amount);
+        // Playerから敵を攻撃した時に呼ばれるユーザ定義関数
+        this._calcCustomCalcDamageFunc();
+        // if( !this._calcCustomCalcDamageFunc() ) {
+            this._status.energy = Math.max(0, this._status.energy - amount);
+        // }
     }
 
     public battleEndProcess(): void {

--- a/packages/engine/src/wwa_parts_player.ts
+++ b/packages/engine/src/wwa_parts_player.ts
@@ -509,6 +509,12 @@ export class Player extends PartsObject {
     }
 
     public damage(amount: number): void {
+        // ダメージが0以下なら何もしない
+        if(amount < 0) {
+            return;
+        }
+        // ENEMY -> PLAYER 攻撃した時に呼ばれるユーザ定義関数
+        const hasUserFunc = this._wwa.callCalcEnemyToPlayerUserDefineFunction();
         this._status.energy = Math.max(0, this._status.energy - amount);
         if (this.isDead()) {
             this._status.energy = 0;
@@ -996,6 +1002,10 @@ export class Player extends PartsObject {
         return this._battleFrameCounter === Consts.BATTLE_INTERVAL_FRAME_NUM && this._battleTurnNum === 0;
     }
 
+    public calcDamage(enemyStatus: Status, playerStatus: Status): number {
+        return enemyStatus.strength - playerStatus.defence;
+    }
+
     public fight(): void {
         if (!this.isFighting()) {
             throw new Error("バトルが開始されていません。");
@@ -1066,13 +1076,14 @@ export class Player extends PartsObject {
             this._battleTurnNum = 0;
             this._enemy = null;
         } else {
+            const damageValue = this.calcDamage(enemyStatus, playerStatus)
             // モンスターターン
-            if (enemyStatus.strength > playerStatus.defence) {
+            if (damageValue > 0) {
                 // プレイヤーがまだ生きてる
-                if (playerStatus.energy > enemyStatus.strength - playerStatus.defence) {
-                    this.damage(enemyStatus.strength - playerStatus.defence);
-                    // モンスター勝利
+                if (playerStatus.energy - damageValue > 0) {
+                    this.damage(damageValue);
                 } else {
+                    // モンスター勝利
                     this.setEnergy(0);
                     this._enemy.battleEndProcess();
                     this._state = PlayerState.CONTROLLABLE;

--- a/packages/engine/src/wwa_parts_player.ts
+++ b/packages/engine/src/wwa_parts_player.ts
@@ -1036,48 +1036,72 @@ export class Player extends PartsObject {
         var playerStatus = this.getStatus();
         var enemyStatus = this._enemy.status;
 
-
         if (this._isPlayerTurn) {
             // プレイヤーターン
-            if (playerStatus.strength > enemyStatus.defence ||
-                playerStatus.defence < enemyStatus.strength) {
-
-                // モンスターがこのターンで死なない場合
-                if (enemyStatus.energy > playerStatus.strength - enemyStatus.defence) {
-                    if (playerStatus.strength > enemyStatus.defence) {
-                        this._enemy.damage(playerStatus.strength - enemyStatus.defence);
-                    }
-
-                    // プレイヤー勝利
+            const defaultDamageValue = this.calcDamage(playerStatus, enemyStatus);
+            this._enemy.damage(defaultDamageValue);
+            // プレイヤー勝利
+            if(this._enemy.status.energy <= 0) {
+                this._wwa.playSound(this._wwa.getObjectAttributeById(this._enemy.partsID, Consts.ATR_SOUND));
+                //                        this._wwa.appearParts(this._enemy.position, AppearanceTriggerType.OBJECT, this._enemy.partsID);
+                this.earnGold(enemyStatus.gold);
+                this._wwa.setStatusChangedEffect(new Status(0, 0, 0, enemyStatus.gold));
+                if (this._enemy.item !== 0) {
+                    this._wwa.setPartsOnPosition(PartsType.OBJECT, this._enemy.item, this._enemy.position);
                 } else {
-                    this._wwa.playSound(this._wwa.getObjectAttributeById(this._enemy.partsID, Consts.ATR_SOUND));
-                    //                        this._wwa.appearParts(this._enemy.position, AppearanceTriggerType.OBJECT, this._enemy.partsID);
-                    this.earnGold(enemyStatus.gold);
-                    this._wwa.setStatusChangedEffect(new Status(0, 0, 0, enemyStatus.gold));
-                    if (this._enemy.item !== 0) {
-                        this._wwa.setPartsOnPosition(PartsType.OBJECT, this._enemy.item, this._enemy.position);
-                    } else {
-                        // 本当はif文でわける必要ないけど、可読性のため設置。
-                        this._wwa.setPartsOnPosition(PartsType.OBJECT, 0, this._enemy.position);
-                    }
-                    // 注)ドロップアイテムがこれによって消えたり変わったりするのは原作からの仕様
-                    this._wwa.reserveAppearPartsInNextFrame(this._enemy.position, AppearanceTriggerType.OBJECT, this._enemy.partsID);
-                    this._state = PlayerState.CONTROLLABLE; // メッセージキューへのエンキュー前にやるのが大事!!(エンキューするとメッセージ待ちになる可能性がある）
-                    this._wwa.generatePageAndReserveExecution(this._enemy.message, false, false, this._enemy.partsID, PartsType.OBJECT, this._enemy.position);
-                    this._enemy.battleEndProcess();
-                    this._battleTurnNum = 0;
-                    this._enemy = null;
+                    // 本当はif文でわける必要ないけど、可読性のため設置。
+                    this._wwa.setPartsOnPosition(PartsType.OBJECT, 0, this._enemy.position);
                 }
-                this._isPlayerTurn = false;
-                return;
+                // 注)ドロップアイテムがこれによって消えたり変わったりするのは原作からの仕様
+                this._wwa.reserveAppearPartsInNextFrame(this._enemy.position, AppearanceTriggerType.OBJECT, this._enemy.partsID);
+                this._state = PlayerState.CONTROLLABLE; // メッセージキューへのエンキュー前にやるのが大事!!(エンキューするとメッセージ待ちになる可能性がある）
+                this._wwa.generatePageAndReserveExecution(this._enemy.message, false, false, this._enemy.partsID, PartsType.OBJECT, this._enemy.position);
+                this._enemy.battleEndProcess();
+                this._battleTurnNum = 0;
+                this._enemy = null;
             }
-            this._enemy.battleEndProcess();
-            const systemMessage = this._wwa.resolveSystemMessage(SystemMessage.Key.CANNOT_DAMAGE_MONSTER);
-            if (systemMessage !== "BLANK") {
-                this._wwa.generatePageAndReserveExecution(systemMessage, false, true);
-            }
-            this._battleTurnNum = 0;
-            this._enemy = null;
+            this._isPlayerTurn = false;
+            // TODO: 勝負がつかないときの処理を書く
+
+            // if (playerStatus.strength > enemyStatus.defence ||
+            //     playerStatus.defence < enemyStatus.strength) {
+
+            //     // モンスターがこのターンで死なない場合
+            //     if (enemyStatus.energy > playerStatus.strength - enemyStatus.defence) {
+            //         if (playerStatus.strength > enemyStatus.defence) {
+            //             this._enemy.damage(playerStatus.strength - enemyStatus.defence);
+            //         }
+
+            //         // プレイヤー勝利
+            //     } else {
+            //         this._wwa.playSound(this._wwa.getObjectAttributeById(this._enemy.partsID, Consts.ATR_SOUND));
+            //         //                        this._wwa.appearParts(this._enemy.position, AppearanceTriggerType.OBJECT, this._enemy.partsID);
+            //         this.earnGold(enemyStatus.gold);
+            //         this._wwa.setStatusChangedEffect(new Status(0, 0, 0, enemyStatus.gold));
+            //         if (this._enemy.item !== 0) {
+            //             this._wwa.setPartsOnPosition(PartsType.OBJECT, this._enemy.item, this._enemy.position);
+            //         } else {
+            //             // 本当はif文でわける必要ないけど、可読性のため設置。
+            //             this._wwa.setPartsOnPosition(PartsType.OBJECT, 0, this._enemy.position);
+            //         }
+            //         // 注)ドロップアイテムがこれによって消えたり変わったりするのは原作からの仕様
+            //         this._wwa.reserveAppearPartsInNextFrame(this._enemy.position, AppearanceTriggerType.OBJECT, this._enemy.partsID);
+            //         this._state = PlayerState.CONTROLLABLE; // メッセージキューへのエンキュー前にやるのが大事!!(エンキューするとメッセージ待ちになる可能性がある）
+            //         this._wwa.generatePageAndReserveExecution(this._enemy.message, false, false, this._enemy.partsID, PartsType.OBJECT, this._enemy.position);
+            //         this._enemy.battleEndProcess();
+            //         this._battleTurnNum = 0;
+            //         this._enemy = null;
+            //     }
+            //     this._isPlayerTurn = false;
+            //     return;
+            // }
+            // this._enemy.battleEndProcess();
+            // const systemMessage = this._wwa.resolveSystemMessage(SystemMessage.Key.CANNOT_DAMAGE_MONSTER);
+            // if (systemMessage !== "BLANK") {
+            //     this._wwa.generatePageAndReserveExecution(systemMessage, false, true);
+            // }
+            // this._battleTurnNum = 0;
+            // this._enemy = null;
         } else {
             // モンスターターン
             const defaultDamageValue = this.calcDamage(enemyStatus, playerStatus)
@@ -1095,8 +1119,8 @@ export class Player extends PartsObject {
                     this._wwa.gameover();
                 }
             }
+            this._isPlayerTurn = true;
         }
-        this._isPlayerTurn = true;
 
     }
 


### PR DESCRIPTION
従来のアルテリオス計算式でダメージ計算式を定義する場合には以下を記述

```
/**
 * プレイヤーから敵に与えるダメージ計算式
 */
function CALC_PLAYER_TO_ENEMY_DAMAGE() {
  v["tmp_enemy_damage"] = (AT - ENEMY_DF)
  if(v["tmp_enemy_damage"] > 0) {
    ENEMY_HP = ENEMY_HP - v["tmp_enemy_damage"];
  }
}

/**
 * 敵からプレイヤーに与えるダメージ計算式
 */
function CALC_ENEMY_TO_PLAYER_DAMAGE() {
  v["tmp_player_damage"] = (ENEMY_AT - DF)
  if(v["tmp_player_damage"] > 0) {
    HP = HP - v["tmp_player_damage"];
  }
}
```

## 確認項目
- [ ] `CALC_PLAYER_TO_ENEMY_DAMAGE` を定義しないとプレイヤーから敵へ従来のダメージ計算式が使われる
- [ ] `CALC_PLAYER_TO_ENEMY_DAMAGE` を定義するとプレイヤーから敵へ定義されたダメージ計算式が使われる
- [ ] 関数内で `ENEMY_HP` `ENEMY_AT` `ENEMY_DF` を左辺値・右辺値共に使える
- [ ] `CALC_ENEMY_TO_PLAYER_DAMAGE` を定義しないと敵からプレイヤーへ従来のダメージ計算式が使われる
- [ ] `CALC_ENEMY_TO_PLAYER_DAMAGE` を定義すると敵からプレイヤーへ定義されたダメージ計算式が使われる
- [ ] プレイヤーがノーダメージの場合・敵がノーダメージの場合にも正しい戦闘の挙動をする
- [ ] 勝負がつかない（20ターン以上敵味方ともダメージが入らない）場合には「勝負がつかない」とウィンドウが出て戦闘が強制終了する