### PR TITLE
fix(save): ユーザ変数が正しくロードできない不具合を修正

### DIFF
--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -4768,7 +4768,7 @@ export class WWA {
         qd.frameCount = this._player.getFrameCount();
         qd.gameSpeedIndex = this._player.getSpeedIndex();
         qd.playTime = this._playTimeCalculator?.calculateTimeMs() ?? 0;
-        qd.userVar = this._userVar.numbered;
+        qd.userVar = this._userVar.numbered.slice();
         qd.userNamedVar = [...this._userVar.named];
 
         switch (callInfo) {


### PR DESCRIPTION
配列のシャローコピーが原因で、DBから直接セーブデータをロードしないケースで値がロードできない不具合を修正します