### PR TITLE
【WWA Script】 $face マクロ相当の機能を WWAScript の関数として追加

### DIFF
--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -181,6 +181,7 @@ function convertCallExpression(node: Acorn.CallExpression): Wwa.WWANode  {
     case "URL_JUMPGATE":
     case "HIDE_STATUS":
     case "PARTS":
+    case "FACE":
     case "EFFECT":
     case "CHANGE_PLAYER_IMAGE":
     case "HAS_ITEM":

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -1,5 +1,5 @@
 import { SystemMessage } from "@wwawing/common-interface";
-import { Coord, MacroStatusIndex, PartsType  } from "../wwa_data";
+import { Coord, Face, MacroStatusIndex, PartsType  } from "../wwa_data";
 import { WWA } from "../wwa_main";
 import * as Wwa from "./wwa";
 
@@ -407,6 +407,30 @@ export class EvalCalcWwaNode {
         }
         // TODO: パーツ番号が最大値を超えていないかチェックする
         this.generator.wwa.replaceParts(srcID, destID, partsType, onlyThisSight);
+        break;
+      }
+      case "FACE": {
+        this._checkArgsLength(6, node);
+        const destPosX = Number(this.evalWwaNode(node.value[0]));
+        const destPosY = Number(this.evalWwaNode(node.value[1]));
+        const srcPosX = Number(this.evalWwaNode(node.value[2]));
+        const srcPosY = Number(this.evalWwaNode(node.value[3]));
+        const srcWidth = Number(this.evalWwaNode(node.value[4]));
+        const srcHeight = Number(this.evalWwaNode(node.value[5]));
+        if (
+          destPosX < 0 || destPosY < 0 ||
+          srcPosX < 0 || srcPosY < 0 ||
+          srcWidth < 0 || srcHeight < 0
+        ) {
+          throw new Error("各引数は0以上の整数でなければなりません。");
+        }
+        this.generator.wwa.addFace(
+          new Face(
+            new Coord(destPosX, destPosY),
+            new Coord(srcPosX, srcPosY),
+            new Coord(srcWidth, srcHeight)
+          )
+        );
         break;
       }
       case "EFFECT": {


### PR DESCRIPTION
`$face` マクロの機能を WWA Script の関数として追加します。
下記の通りに実行すると、 `MSG` 関数で `FACE` 関数に指定したイメージが表示されます。

```
FACE(80,140,7,15,2,2);
FACE(280,140,5,15,2,2);
MSG("Ｖｅｒ３．１から頻出処理である\nイベント時の顔画像表示をサポートするマクロ文を追加しています。");
```

現時点では `MSG` 関数による改ページには対応していません。 `MSG` の後に `FACE` 関数を実行しようとした場合は、 Script 文の中のすべての `FACE` 関数のイメージが最初のメッセージに表示されます。
（今後解消する予定です。）

```
FACE(80,140,7,15,2,2);
FACE(280,140,5,15,2,2);
// ここで下2つの FACE もまとめて表示される
MSG("Ｖｅｒ３．１から頻出処理である\nイベント時の顔画像表示をサポートするマクロ文を追加しています。");
FACE(100,140,7,15,2,2);
FACE(260,140,5,15,2,2);
// ここは何も FACE が表示されない
MSG("「＝」のあとに表示するＸ座標、\nＹ座標（ドット単位です。注意）\nそのあとに表示元画像のＸ座標、\nＹ座標（こちらはパーツ単位です）\nそのあとに画像のＸ方向の幅、\nＹ方向の幅（パーツ単位）で\n指定します。");
```