### PR TITLE
fix(battle): 戦闘関連のフリーズと予測詐欺を軽減

### DIFF
--- a/packages/engine/src/wwa_data.ts
+++ b/packages/engine/src/wwa_data.ts
@@ -1073,6 +1073,12 @@ export interface BattleTurnResult {
      * 中断した場合でも該当ターンのダメージは入ります。
      */
     aborted?: boolean;
+    /**
+     * ユーザー定義関数で予期せぬエラーがあった場合 true
+     * ほとんど起きないと思いますが念のため。
+     * エラーがあった場合はダメージは 0 となります。
+     */
+    hasError?: boolean
 }
 
 
@@ -1083,3 +1089,9 @@ export interface BattleEstimateParameters {
     playerStatus: Status;
     enemyStatus: Status
 }
+
+
+/**
+ * 戦闘ダメージ方向の定義
+ */
+export type BattleDamageDirection = "playerToEnemy" | "enemyToPlayer";

--- a/packages/engine/src/wwa_estimate_battle.ts
+++ b/packages/engine/src/wwa_estimate_battle.ts
@@ -172,6 +172,7 @@ function calc(
     let estimatedDamage = 0;
     let turnLength = 0;
     let noDamageTurnLength = 0;
+    const playerEnergyBeforeBattle = playerStatus.energy;
 
     // デフォルトダメージ関数を使っている場合の攻撃無効判定
     if(
@@ -198,7 +199,9 @@ function calc(
         if (clonedMonster.status.energy <= 0) {
             return { estimatedDamage };
         } else if (noDamageTurnLength > WWAConsts.FIGHT_DRAW_TURN || playerTurnResult.aborted)  {
-            return { noSettled: true, estimatedDamage }
+            // プレイヤー生命力が負になってもダメージシミュレーションは継続するため、中断が呼ばれた時にプレイヤーがゲームオーバーなら勝負がついているので注意
+            // ただし、戦闘開始前にプレイヤー生命力が 0 (以下) だった場合は、初手で中断を食らってもゲームオーバー判定にならないので勝負がつかない判定となる
+            return { noSettled: (playerEnergyBeforeBattle <= 0 || clonedPlayerStatus.energy > 0) && clonedMonster.status.energy > 0, estimatedDamage }
         } else if (turnLength > 20000) {
             return { isOverMaxTurn: true, estimatedDamage: 0 };
         }
@@ -213,7 +216,7 @@ function calc(
         estimatedDamage += damageEnemyToPlayer;
         clonedPlayerStatus.energy = Math.max(clonedPlayerStatus.energy - damageEnemyToPlayer, 0);
         if (noDamageTurnLength > WWAConsts.FIGHT_DRAW_TURN || enemyTurnResult.aborted)  {
-            return { noSettled: true, estimatedDamage }
+            return { noSettled: (playerEnergyBeforeBattle <= 0 || clonedPlayerStatus.energy > 0) && clonedMonster.status.energy > 0, estimatedDamage }
         } else if (turnLength > 20000) {
             return { isOverMaxTurn: true, estimatedDamage: 0 };
         }

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -9,7 +9,7 @@ import {
     SystemSound, loadMessages, sidebarButtonCellElementID, SpeedChange, PartsType,
     speedNameList, MoveType, AppearanceTriggerType, vx, vy, EquipmentStatus, SecondCandidateMoveType,
     ChangeStyleType, MacroStatusIndex, SelectorType, IDTable, UserDevice, OS_TYPE, DEVICE_TYPE, BROWSER_TYPE, ControlPanelBottomButton, MacroImgFrameIndex, DrawPartsData,
-    StatusKind, MacroType, StatusSolutionKind, UserVarNameListRequestErrorKind, ScoreOptions, TriggerParts, type UserVariableKind, type BattleTurnResult, BattleEstimateParameters
+    StatusKind, MacroType, StatusSolutionKind, UserVarNameListRequestErrorKind, ScoreOptions, TriggerParts, type UserVariableKind, type BattleTurnResult, BattleEstimateParameters, BattleDamageDirection
 } from "./wwa_data";
 
 import {
@@ -1225,41 +1225,40 @@ export class WWA {
     }
 
     /**
-     * 戦闘でPlayerToEnemyのダメージ発生時のユーザ定義独自関数を呼び出す
+     * damageDirection に応じた のユーザ定義ダメージ関数を呼び出す
+     * ユーザ定義ダメージ関数の結果が数値でない場合は 0 とします。
+     * ダメージ計算結果に小数部分が含まれる場合は整数部分をダメージとします。
      * @returns 定義されていればその結果, 未定義なら undefined. 
      **/
-    public callCalcPlayerToEnemyUserDefineFunction(estimatingParams?: BattleEstimateParameters): BattleTurnResult | undefined {
-        const calcPlayerToEnemyFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALC_PLAYER_TO_ENEMY_DAMAGE"];
-        if (calcPlayerToEnemyFunc) {
+    public callUserDefinedBattleDamageFunction(damageDirection: BattleDamageDirection, estimatingParams?: BattleEstimateParameters): BattleTurnResult | undefined {
+        const userDefinedFunctionNode = this.getUserDefinedDamageFunctionNode(damageDirection);
+        if (userDefinedFunctionNode) {
             this.evalCalcWwaNodeGenerator.setBattleDamageCalculationMode(estimatingParams);
-            const damage = this.evalCalcWwaNodeGenerator.evalWwaNode(calcPlayerToEnemyFunc);
-            const aborted = this.evalCalcWwaNodeGenerator.state.battleDamageCalculation.aborted;
-            this.evalCalcWwaNodeGenerator.clearBattleDamageCalculationMode();
-            if (typeof damage !== "number") {
-                throw new Error(`ダメージ方程式の結果が数値になっていません: ${damage}`);
+            try {
+                const damage = this.evalCalcWwaNodeGenerator.evalWwaNode(userDefinedFunctionNode);
+                const aborted = this.evalCalcWwaNodeGenerator.state.battleDamageCalculation.aborted;
+                this.evalCalcWwaNodeGenerator.clearBattleDamageCalculationMode();
+                if (typeof damage === "number") {
+                    return { damage: this.toAssignableValue(damage), aborted };
+                } else {
+                    console.warn(`${damageDirection} のダメージ計算結果が数値になりませんでした。(結果: ${damage})。このターンのダメージは無効になります。`);
+                    return { damage: 0, aborted };
+                }
+            } catch (error) {
+                console.warn(`${damageDirection} のダメージ計算中にエラーが発生しました。このターンのダメージは無効になります。`);
+                console.warn(error);
+                return { damage: 0, hasError: true };
             }
-            return { damage, aborted };
         }
         return undefined;
     }
 
-    /**
-     * 戦闘でEnemyToPlayerのダメージ発生時のユーザ定義独自関数を呼び出す
-     * @returns 定義されていればその結果, 未定義なら undefined. 
-     */
-    public callCalcEnemyToPlayerUserDefineFunction(estimatingParams?: BattleEstimateParameters): BattleTurnResult | undefined {
-        const calcEnemyToPlayerFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALC_ENEMY_TO_PLAYER_DAMAGE"];
-        if (calcEnemyToPlayerFunc) {
-            this.evalCalcWwaNodeGenerator.setBattleDamageCalculationMode(estimatingParams);
-            const damage = this.evalCalcWwaNodeGenerator.evalWwaNode(calcEnemyToPlayerFunc);
-            const aborted = this.evalCalcWwaNodeGenerator.state.battleDamageCalculation.aborted;
-            this.evalCalcWwaNodeGenerator.clearBattleDamageCalculationMode();
-            if (typeof damage !== "number") {
-                throw new Error(`ダメージ方程式の結果が数値になっていません: ${damage}`);
-            }
-            return { damage, aborted };
-        }
-        return undefined;
+    private getUserDefinedDamageFunctionNode(damageDirection: BattleDamageDirection): WWANode | undefined {
+        const directionFunctionMap: {[KEY in BattleDamageDirection]: string} = {
+            "playerToEnemy": "CALC_PLAYER_TO_ENEMY_DAMAGE",
+            "enemyToPlayer": "CALC_ENEMY_TO_PLAYER_DAMAGE"
+        };
+        return this.userDefinedFunctions?.[directionFunctionMap[damageDirection]];
     }
 
     /** プレイヤーが動いた際のユーザ定義独自関数を呼び出す */
@@ -5427,8 +5426,8 @@ export class WWA {
 
     public isUsingDefaultDamageCalcFunction(): boolean {
         return (
-            this.callCalcPlayerToEnemyUserDefineFunction() === undefined &&
-            this.callCalcEnemyToPlayerUserDefineFunction() === undefined
+            this.getUserDefinedDamageFunctionNode("enemyToPlayer") === undefined &&
+            this.getUserDefinedDamageFunctionNode("playerToEnemy") === undefined
         );
     }
 

--- a/packages/engine/src/wwa_parts_player.ts
+++ b/packages/engine/src/wwa_parts_player.ts
@@ -1007,7 +1007,7 @@ export class Player extends PartsObject {
     }
 
     public calcBattleResultForPlayerTurn(playerStatus: Status, enemyStatus: Status, estimating: boolean = false): BattleTurnResult {
-        const userDefinedDamageResult = this._wwa.callCalcPlayerToEnemyUserDefineFunction((estimating || undefined) && {
+        const userDefinedDamageResult = this._wwa.callUserDefinedBattleDamageFunction("playerToEnemy", (estimating || undefined) && {
             playerStatus,
             enemyStatus
         });
@@ -1018,7 +1018,7 @@ export class Player extends PartsObject {
     }
 
     public calcBattleResultForEnemyTurn(enemyStatus: Status, playerStatus: Status, estimating: boolean = false): BattleTurnResult {
-        const userDefinedDamageResult = this._wwa.callCalcEnemyToPlayerUserDefineFunction((estimating || undefined) && {
+        const userDefinedDamageResult = this._wwa.callUserDefinedBattleDamageFunction("enemyToPlayer", (estimating || undefined) && {
             playerStatus,
             enemyStatus
         });


### PR DESCRIPTION
- カスタムダメージ関数で数値でない値を返したり、値を返さなかったりした場合にフリーズしないようにしました
- 戦闘予測時にプレイヤー生命力が0より小さくなったあとに中断された場合に勝負がつかない判定になる詐欺結果と、戦闘前にプレイヤーの生命力が0の場合に戦闘予測の結果が詐欺気味になるのを修正しました