### PR TITLE
feat: 【ピクチャ機能】プロパティをオブジェクト形式で表記できるようにする

### DIFF
--- a/packages/engine/src/wwa_expression2/acorn.ts
+++ b/packages/engine/src/wwa_expression2/acorn.ts
@@ -138,5 +138,11 @@ export interface Property extends Node {
 }
 
 export interface ObjectExpression extends Node {
+  type: "ObjectExpression";
   properties: Property[];
+}
+
+export interface ArrayExpression extends Node {
+  type: "ArrayExpression";
+  elements: Node[];
 }

--- a/packages/engine/src/wwa_expression2/acorn.ts
+++ b/packages/engine/src/wwa_expression2/acorn.ts
@@ -133,7 +133,7 @@ export interface ConditionalExpression extends Node {
 
 export interface Property extends Node {
   type: "Property";
-  key: Identifier;
+  key: Identifier | Literal;
   value: Node;
 }
 

--- a/packages/engine/src/wwa_expression2/acorn.ts
+++ b/packages/engine/src/wwa_expression2/acorn.ts
@@ -130,3 +130,13 @@ export interface ConditionalExpression extends Node {
   consequent: Node;
   alternate: Node;
 }
+
+export interface Property extends Node {
+  type: "Property";
+  key: Identifier;
+  value: Node;
+}
+
+export interface ObjectExpression extends Node {
+  properties: Property[];
+}

--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -514,13 +514,16 @@ function convertConditionalExpression(node: Acorn.ConditionalExpression): Wwa.WW
 }
 
 function convertProperty(node: Acorn.Property): Wwa.Property {
-  const keyIdentifier = convertIdentifer(node.key);
-  if (keyIdentifier.type === "Symbol") {
-    throw new Error(`Object のキー ${keyIdentifier.name} は予約されているため、使用できません。`);
+  const key = convertNodeAcornToWwa(node.key);
+  if (key.type === "Symbol") {
+    throw new Error(`Object のキー ${key.name} は予約されているため、使用できません。`);
+  }
+  if (key.type !== "Literal") {
+    throw new Error(`Object のキーが不正です。 Literal を期待していましたが、実際は ${key.type} でした。`);
   }
   return {
     type: "Property",
-    key: keyIdentifier,
+    key,
     value: convertNodeAcornToWwa(node.value),
   };
 }

--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -482,7 +482,10 @@ function convertIdentifer(node: Acorn.Identifier): Wwa.Symbol | Wwa.Literal {
         name: node.name
       }
     default:  
-      throw new Error("未定義のシンボルです :\n"+ node.name);
+      return {
+        type: "Literal",
+        value: node.name
+      };
   }
 }
 
@@ -509,9 +512,13 @@ function convertConditionalExpression(node: Acorn.ConditionalExpression): Wwa.WW
 }
 
 function convertProperty(node: Acorn.Property): Wwa.Property {
+  const keyIdentifier = convertIdentifer(node.key);
+  if (keyIdentifier.type === "Symbol") {
+    throw new Error(`Object のキー ${keyIdentifier.name} は予約されているため、使用できません。`);
+  }
   return {
     type: "Property",
-    key: node.key,
+    key: keyIdentifier,
     value: convertNodeAcornToWwa(node.value),
   };
 }

--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -59,6 +59,8 @@ export function convertNodeAcornToWwa(node: Acorn.Node): Wwa.WWANode {
         return convertProperty(node as Acorn.Property);
       case "ObjectExpression":
         return convertObjectExpression(node as Acorn.ObjectExpression);
+      case "ArrayExpression":
+        return convertArrayExpression(node as Acorn.ArrayExpression);
       default:
         console.log(node);
         throw new Error("未定義の AST ノードです :" + node.type);
@@ -528,4 +530,11 @@ function convertObjectExpression(node: Acorn.ObjectExpression): Wwa.ObjectExpres
     type: "ObjectExpression",
     properties: node.properties.map(convertProperty),
   };
+}
+
+function convertArrayExpression(node: Acorn.ArrayExpression): Wwa.ArrayExpression {
+  return {
+    type: "ArrayExpression",
+    elements: node.elements.map(convertNodeAcornToWwa),
+  }
 }

--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -54,7 +54,11 @@ export function convertNodeAcornToWwa(node: Acorn.Node): Wwa.WWANode {
       case "TemplateElement":
         return convertTemplateElement(node as Acorn.TemplateElement);
       case "ConditionalExpression":
-        return convertConditionalExpression(node as Acorn.ConditionalExpression)
+        return convertConditionalExpression(node as Acorn.ConditionalExpression);
+      case "Property":
+        return convertProperty(node as Acorn.Property);
+      case "ObjectExpression":
+        return convertObjectExpression(node as Acorn.ObjectExpression);
       default:
         console.log(node);
         throw new Error("未定義の AST ノードです :" + node.type);
@@ -501,5 +505,20 @@ function convertConditionalExpression(node: Acorn.ConditionalExpression): Wwa.WW
     consequent: consequent,
     test: test,
     alternate: alternate
+  };
+}
+
+function convertProperty(node: Acorn.Property): Wwa.Property {
+  return {
+    type: "Property",
+    key: node.key,
+    value: convertNodeAcornToWwa(node.value),
+  };
+}
+
+function convertObjectExpression(node: Acorn.ObjectExpression): Wwa.ObjectExpression {
+  return {
+    type: "ObjectExpression",
+    properties: node.properties.map(convertProperty),
   };
 }

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -181,6 +181,8 @@ export class EvalCalcWwaNode {
         return this.property(node);
       case "ObjectExpression":
         return this.objectExpression(node);
+      case "ArrayExpression":
+        return this.arrayExpression(node);
       default:
         console.log(node);
         throw new Error("未定義または未実装のノードです");
@@ -712,6 +714,10 @@ export class EvalCalcWwaNode {
       // TODO もし properties に Properties 以外の Node が混入したら？
       node.properties.map((property) => this.evalWwaNode(property))
     );
+  }
+
+  arrayExpression(node: Wwa.ArrayExpression) {
+    return node.elements.map((element) => this.evalWwaNode(element));
   }
 
   /**

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -177,7 +177,10 @@ export class EvalCalcWwaNode {
         return this.convertTemplateLiteral(node);
       case "ConditionalExpression":
         return this.convertConditionalExpression(node);
-      // TODO ObjectExpression を実装する
+      case "Property":
+        return this.property(node);
+      case "ObjectExpression":
+        return this.objectExpression(node);
       default:
         console.log(node);
         throw new Error("未定義または未実装のノードです");
@@ -597,11 +600,14 @@ export class EvalCalcWwaNode {
           this.generator.wwa.deletePictureRegistry(layerNumber);
           return;
         }
-        if (typeof propertyDefinition !== "string") {
-          throw new Error("ピクチャのプロパティ定義は文字列である必要があります。")
+        if (typeof propertyDefinition === "object") {
+          this.generator.wwa.setPictureRegistryFromObject(layerNumber, propertyDefinition);
+        } else if (typeof propertyDefinition === "string") {
+          // TODO パーツ座標は本来なら実行元パーツの座標にすべきだが、イベント関数では判別できない。
+          this.generator.wwa.setPictureRegistryFromRawText(layerNumber, propertyDefinition);
+        } else {
+          throw new Error("ピクチャのプロパティ定義は文字列あるいはオブジェクトである必要があります。")
         }
-        // TODO パーツ座標は本来なら実行元パーツの座標にすべきだが、イベント関数では判別できない。
-        this.generator.wwa.setPictureRegistryFromRawText(layerNumber, propertyDefinition);
         break;
       }
       case "PICTURE_FROM_PARTS": {
@@ -695,6 +701,17 @@ export class EvalCalcWwaNode {
     const target = ifResult? node.consequent: node.alternate;
     const value = this.evalWwaNode(target)
     return value;
+  }
+
+  property(node: Wwa.Property) {
+    return [this.evalWwaNode(node.key), this.evalWwaNode(node.value)];
+  }
+
+  objectExpression(node: Wwa.ObjectExpression) {
+    return Object.fromEntries(
+      // TODO もし properties に Properties 以外の Node が混入したら？
+      node.properties.map((property) => this.evalWwaNode(property))
+    );
   }
 
   /**

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -177,6 +177,7 @@ export class EvalCalcWwaNode {
         return this.convertTemplateLiteral(node);
       case "ConditionalExpression":
         return this.convertConditionalExpression(node);
+      // TODO ObjectExpression を実装する
       default:
         console.log(node);
         throw new Error("未定義または未実装のノードです");

--- a/packages/engine/src/wwa_expression2/wwa.ts
+++ b/packages/engine/src/wwa_expression2/wwa.ts
@@ -1,6 +1,7 @@
 export type Calcurable = Array1D | Array2D | Literal | Symbol | UnaryOperation | BinaryOperation;
 
 export function isCalcurable(node: WWANode): node is Calcurable {
+  // ObjectExpression と ArrayExpression はピクチャ機能でしか使用しないためサポート対象外
   const supportType = ["Array1D", "Array2D", "Literal", "Symbol", "UnaryOperation", "BinaryOperation", "Random", "CallDefinedFunction", "AnyFunction", "ConditionalExpression"];
   return supportType.includes(node.type);
 }

--- a/packages/engine/src/wwa_expression2/wwa.ts
+++ b/packages/engine/src/wwa_expression2/wwa.ts
@@ -1,4 +1,4 @@
-import { ReturnStatement } from "./acorn";
+import { Identifier, ReturnStatement } from "./acorn";
 
 export type Calcurable = Array1D | Array2D | Literal | Symbol | UnaryOperation | BinaryOperation;
 
@@ -175,6 +175,18 @@ export interface ConditionalExpression {
   alternate: WWANode
 }
 
+export interface Property {
+  type: "Property",
+  key: Identifier,
+  value: WWANode,
+  // TODO 他にもありそう
+}
+
+export interface ObjectExpression {
+  type: "ObjectExpression",
+  properties: Property[],
+}
+
 export type WWANode = |
   PartsAssignment |
   ItemAssignment |
@@ -203,4 +215,6 @@ export type WWANode = |
   LogicalExpression |
   TemplateLiteral |
   TemplateElement |
-  ConditionalExpression;
+  ConditionalExpression |
+  Property |
+  ObjectExpression;

--- a/packages/engine/src/wwa_expression2/wwa.ts
+++ b/packages/engine/src/wwa_expression2/wwa.ts
@@ -1,5 +1,3 @@
-import { Identifier, ReturnStatement } from "./acorn";
-
 export type Calcurable = Array1D | Array2D | Literal | Symbol | UnaryOperation | BinaryOperation;
 
 export function isCalcurable(node: WWANode): node is Calcurable {
@@ -177,7 +175,7 @@ export interface ConditionalExpression {
 
 export interface Property {
   type: "Property",
-  key: Identifier,
+  key: Literal,
   value: WWANode,
   // TODO 他にもありそう
 }

--- a/packages/engine/src/wwa_expression2/wwa.ts
+++ b/packages/engine/src/wwa_expression2/wwa.ts
@@ -185,6 +185,11 @@ export interface ObjectExpression {
   properties: Property[],
 }
 
+export interface ArrayExpression {
+  type: "ArrayExpression",
+  elements: WWANode[]
+}
+
 export type WWANode = |
   PartsAssignment |
   ItemAssignment |
@@ -215,4 +220,5 @@ export type WWANode = |
   TemplateElement |
   ConditionalExpression |
   Property |
-  ObjectExpression;
+  ObjectExpression |
+  ArrayExpression;

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -6127,6 +6127,12 @@ export class WWA {
         this.updatePicturesCache();
     }
 
+    public setPictureRegistryFromObject(layerNumber: number, properties: object) {
+        const data = this._cgManager.picture.registerPictureFromObject(layerNumber, properties);
+        this._wwaData.pictureRegistry = data;
+        this.updatePicturesCache();
+    }
+
     public deletePictureRegistry(layerNumber: number) {
         const data = this._cgManager.picture.deletePicture(layerNumber);
         this._wwaData.pictureRegistry = data;

--- a/packages/engine/src/wwa_picture/WWAPicture.ts
+++ b/packages/engine/src/wwa_picture/WWAPicture.ts
@@ -2,7 +2,7 @@ import { CacheCanvas } from "../wwa_cgmanager";
 import { Coord, PartsType, WWAConsts } from "../wwa_data";
 import { PicturePropertyDefinitions } from "./config";
 import { PictureExternalImageItem, PictureRegistryParts } from "./typedef";
-import { PictureRegistry } from "@wwawing/common-interface/lib/wwa_data";
+import { PictureRegistry, RawPictureRegistry } from "@wwawing/common-interface/lib/wwa_data";
 import { checkValuesFromRawRegistry, convertPictureRegistryFromText, convertVariablesFromRawRegistry } from "./utils";
 import { WWA } from "../wwa_main";
 import WWAPictureItem from "./WWAPictureItem";
@@ -111,24 +111,22 @@ export default class WWAPicutre {
     }
 
     /**
-     * ピクチャをテキストデータから登録し、追加後のピクチャをデータにして返します。
+     * ピクチャを Object 形式のデータから登録し、追加後のピクチャをデータにして返します。
      * プロパティの変換は WWAPicture クラス内で行われます。
-     * @param regitory ピクチャの登録情報
+     * @param rawRegitry ピクチャの登録情報 (プロパティの変数参照は未変換の状態とする)
      * @param targetPartsID 対象のパーツ番号
      * @param targetPartsType 対象のパーツ種類
-     * @param triggerPartsPosition 実行元パーツの座標
      * @returns wwaData で使用できるピクチャの登録データ（配列形式）
      */
-    public registerPictureFromText(
-        registry: PictureRegistryParts,
+    public registerPictureFromRawRegistry(
+        rawRegistry: RawPictureRegistry,
         targetPartsID: number,
         targetPartsType: PartsType,
     ) {
-        const rawRegistry = convertPictureRegistryFromText(registry);
         this.registerPicture(convertVariablesFromRawRegistry(rawRegistry, this._wwa.generateTokenValues({
             id: targetPartsID,
             type: targetPartsType,
-            position: new Coord(registry.triggerPartsX, registry.triggerPartsY)
+            position: new Coord(rawRegistry.triggerPartsX, rawRegistry.triggerPartsY)
         })));
         return this.getPictureRegistryData();
     }

--- a/packages/engine/src/wwa_picture/WWAPicture.ts
+++ b/packages/engine/src/wwa_picture/WWAPicture.ts
@@ -160,6 +160,25 @@ export default class WWAPicutre {
         return this.getPictureRegistryData();
     }
 
+    public registerPictureFromObject(
+        layerNumber: number,
+        properties: object
+    ) {
+        this.registerPicture(
+            checkValuesFromRawRegistry({
+                imgPosX: 0,
+                imgPosY: 0,
+                imgPosX2: 0,
+                imgPosY2: 0,
+                layerNumber,
+                triggerPartsX: 0,
+                triggerPartsY: 0,
+                properties
+            })
+        );
+        return this.getPictureRegistryData();
+    }
+
     /**
      * ピクチャの登録を削除し、削除後のピクチャをデータにして返します。
      * @param layerNumber 削除したいレイヤーの番号


### PR DESCRIPTION
ピクチャ機能のプロパティの変換方法を変更します。
これまではプロパティを JSON.parse で変換していましたが、これからは WWAScript の Acorn と同じシステムで変換するようにします。

![wwa_picture_properties_with_object_expression_and_array_expression](https://github.com/WWAWing/WWAWing/assets/12381375/8605bbef-48bf-465a-82e6-5d394bc61af9)

## 理由
- プロパティの名前に引用符書くのがダルい
- テキストの改行文字問題（テンプレート文字列では直接 `\n` で書けない）
- 最後のプロパティでカンマ必要なのかよく分からない
- 今後ステータスや変数を連動して表示する際の準備（関連: #689 ）

## 互換性の問題について
ほぼほぼ大丈夫かと思います。
JavaScript では JSON のテキストをそのまま貼り付けてもオブジェクトとして解釈してくれるので、 Acorn も同じように解釈されると思います。
今のところテストマップのすべてのプロパティは稼働できています。