### PR TITLE
feat: 【WWA Script】指定したIDパーツのマップ画像上のIDを取得出来る関数を実装しました

### DIFF
--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -204,6 +204,8 @@ function convertCallExpression(node: Acorn.CallExpression): Wwa.WWANode  {
     case "GET_GAMEOVER_POS_Y":
     case "ABORT_BATTLE":
     case "EXIT":
+    case "GET_IMG_POS_X":
+    case "GET_IMG_POS_Y":
       return execAnyFunction(node.arguments, functionName);
     default:
       return {

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -615,9 +615,14 @@ export class EvalCalcWwaNode {
       case "GET_IMG_POS_X": {
         this._checkArgsLength(1, node);
         const parts_id = Number(this.evalWwaNode(node.value[0]));
-        const parts_type = Number(this.evalWwaNode(node.value[1])) === 0? PartsType.OBJECT: PartsType.MAP;
-        const is_first_motion = Number(this.evalWwaNode(node.value[2])) === 0;
+        const parts_type_number = (node.value[1] !== undefined)?
+          Number(this.evalWwaNode(node.value[1])):
+          0;
+        const parts_type = parts_type_number === 0? PartsType.OBJECT: PartsType.MAP;
         if(parts_type === PartsType.OBJECT) {
+          const is_first_motion: boolean = (node.value[2] !== undefined)?
+            Number(this.evalWwaNode(node.value[2])) === 0:
+            true;
           // 物体パーツの情報を取得する
           const obj_info = this.generator.wwa.getObjectInfo(parts_id);
           return is_first_motion? obj_info[WWAConsts.ATR_X]: obj_info[WWAConsts.ATR_X2];
@@ -632,9 +637,14 @@ export class EvalCalcWwaNode {
       case "GET_IMG_POS_Y": {
         this._checkArgsLength(1, node);
         const parts_id = Number(this.evalWwaNode(node.value[0]));
-        const parts_type = Number(this.evalWwaNode(node.value[1])) === 0? PartsType.OBJECT: PartsType.MAP;
-        const is_first_motion = Number(this.evalWwaNode(node.value[2])) === 0;
+        const parts_type_number = (node.value[1] !== undefined)?
+          Number(this.evalWwaNode(node.value[1])):
+          0;
+        const parts_type = parts_type_number === 0? PartsType.OBJECT: PartsType.MAP;
         if(parts_type === PartsType.OBJECT) {
+          const is_first_motion: boolean = (node.value[2] !== undefined)?
+            Number(this.evalWwaNode(node.value[2])) === 0:
+            true;
           // 物体パーツの情報を取得する
           const obj_info = this.generator.wwa.getObjectInfo(parts_id);
           return is_first_motion? obj_info[WWAConsts.ATR_Y]: obj_info[WWAConsts.ATR_Y2];

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -625,12 +625,14 @@ export class EvalCalcWwaNode {
             true;
           // 物体パーツの情報を取得する
           const obj_info = this.generator.wwa.getObjectInfo(parts_id);
-          return is_first_motion? obj_info[WWAConsts.ATR_X]: obj_info[WWAConsts.ATR_X2];
+          const ims_pos = is_first_motion? obj_info[WWAConsts.ATR_X]: obj_info[WWAConsts.ATR_X2];
+          return Math.floor(ims_pos / WWAConsts.CHIP_SIZE);
         }
         else if(parts_type === PartsType.MAP) {
           // 背景パーツの情報を取得する
           const map_info = this.generator.wwa.getMapInfo(parts_id);
-          return map_info[WWAConsts.ATR_X]
+          const ims_pos = map_info[WWAConsts.ATR_X];
+          return Math.floor(ims_pos / WWAConsts.CHIP_SIZE);
         }
         throw new Error("GET_IMG_POS_X: 指定したIDのパーツのTypeが異常です。");
       }
@@ -647,12 +649,14 @@ export class EvalCalcWwaNode {
             true;
           // 物体パーツの情報を取得する
           const obj_info = this.generator.wwa.getObjectInfo(parts_id);
-          return is_first_motion? obj_info[WWAConsts.ATR_Y]: obj_info[WWAConsts.ATR_Y2];
+          const ims_pos = is_first_motion? obj_info[WWAConsts.ATR_Y]: obj_info[WWAConsts.ATR_Y2];
+          return Math.floor(ims_pos / WWAConsts.CHIP_SIZE);
         }
         else if(parts_type === PartsType.MAP) {
           // 背景パーツの情報を取得する
           const map_info = this.generator.wwa.getMapInfo(parts_id);
-          return map_info[WWAConsts.ATR_Y]
+          const ims_pos = map_info[WWAConsts.ATR_Y];
+          return Math.floor(ims_pos / WWAConsts.CHIP_SIZE);
         }
         throw new Error("GET_IMG_POS_Y: 指定したIDのパーツのTypeが異常です。");
       }

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -1,5 +1,5 @@
 import { SystemMessage } from "@wwawing/common-interface";
-import { BattleEstimateParameters, Coord, Face, MacroStatusIndex, PartsType  } from "../wwa_data";
+import { BattleEstimateParameters, Coord, Face, MacroStatusIndex, PartsType, WWAConsts  } from "../wwa_data";
 import { WWA } from "../wwa_main";
 import * as Wwa from "./wwa";
 
@@ -612,6 +612,40 @@ export class EvalCalcWwaNode {
       }
       case "EXIT": 
         throw new ExitInformation("EXIT", this.evalWwaNode(node.value[0]));
+      case "GET_IMG_POS_X": {
+        this._checkArgsLength(1, node);
+        const parts_id = Number(this.evalWwaNode(node.value[0]));
+        const parts_type = Number(this.evalWwaNode(node.value[1])) === 0? PartsType.OBJECT: PartsType.MAP;
+        const is_first_motion = Number(this.evalWwaNode(node.value[2])) === 0;
+        if(parts_type === PartsType.OBJECT) {
+          // 物体パーツの情報を取得する
+          const obj_info = this.generator.wwa.getObjectInfo(parts_id);
+          return is_first_motion? obj_info[WWAConsts.ATR_X]: obj_info[WWAConsts.ATR_X2];
+        }
+        else if(parts_type === PartsType.MAP) {
+          // 背景パーツの情報を取得する
+          const map_info = this.generator.wwa.getMapInfo(parts_id);
+          return map_info[WWAConsts.ATR_X]
+        }
+        throw new Error("GET_IMG_POS_X: 指定したIDのパーツのTypeが異常です。");
+      }
+      case "GET_IMG_POS_Y": {
+        this._checkArgsLength(1, node);
+        const parts_id = Number(this.evalWwaNode(node.value[0]));
+        const parts_type = Number(this.evalWwaNode(node.value[1])) === 0? PartsType.OBJECT: PartsType.MAP;
+        const is_first_motion = Number(this.evalWwaNode(node.value[2])) === 0;
+        if(parts_type === PartsType.OBJECT) {
+          // 物体パーツの情報を取得する
+          const obj_info = this.generator.wwa.getObjectInfo(parts_id);
+          return is_first_motion? obj_info[WWAConsts.ATR_Y]: obj_info[WWAConsts.ATR_Y2];
+        }
+        else if(parts_type === PartsType.MAP) {
+          // 背景パーツの情報を取得する
+          const map_info = this.generator.wwa.getMapInfo(parts_id);
+          return map_info[WWAConsts.ATR_Y]
+        }
+        throw new Error("GET_IMG_POS_Y: 指定したIDのパーツのTypeが異常です。");
+      }
       default:
         throw new Error("未定義の関数が指定されました: "+node.functionName);
     }

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -1280,7 +1280,6 @@ export class WWA {
             return;
         }
         const readScriptWWANodes = this.convertWwaNodes(userScriptStrings.data);
-        console.log(readScriptWWANodes);
         readScriptWWANodes.forEach((currentNode) => {
             if(currentNode.type === 'DefinedFunction' && this.userDefinedFunctions) {
                 const functionName = currentNode.functionName;
@@ -3206,12 +3205,18 @@ export class WWA {
         return this._wwaData.systemMessage[messageID];
     }
 
+    // 背景パーツ情報取得
+    public getMapInfo(partsID: number): number[] {
+        return this._wwaData.mapAttribute[partsID];
+    }
+
     // 背景パーツ判定
     public checkMap(pos?: Coord): boolean {
         var playerPos = this._player.getPosition().getPartsCoord();
         pos = (pos !== void 0 && pos !== null) ? pos : playerPos;
         var partsID: number = this._wwaData.map[pos.y][pos.x];
-        var mapAttr: number = this._wwaData.mapAttribute[partsID][Consts.ATR_TYPE];
+        const mapInfo = this.getMapInfo(partsID);
+        var mapAttr: number = mapInfo[Consts.ATR_TYPE];
         var isPlayerPositionExec = (pos.x === playerPos.x && pos.y === playerPos.y);
         var eventExecuted: boolean = false;
         if (isPlayerPositionExec) {
@@ -3240,12 +3245,18 @@ export class WWA {
 
     }
 
+    // 物体パーツ情報取得
+    public getObjectInfo(partsID: number): number[] {
+        return this._wwaData.objectAttribute[partsID];
+    }
+
     // 物体パーツ判定
     public checkObject(pos?: Coord): void {
         var playerPos = this._player.getPosition().getPartsCoord();
         pos = (pos !== void 0 && pos !== null) ? pos : playerPos;
         var partsID: number = this._wwaData.mapObject[pos.y][pos.x];
-        var objAttr: number = this._wwaData.objectAttribute[partsID][Consts.ATR_TYPE];
+        const objInfo = this.getObjectInfo(partsID);
+        var objAttr: number = objInfo[Consts.ATR_TYPE];
         var isPlayerPositionExec = (pos.x === playerPos.x && pos.y === playerPos.y);
         if (isPlayerPositionExec) {
             if (this._player.getLastExecPartsIDOnSamePosition(PartsType.OBJECT) === partsID) {
@@ -6924,7 +6935,8 @@ font-weight: bold;
             userVars: this._userVar.numbered,
             playerCoord: this._player.getPosition().getPartsCoord(),
             playerDirection: this._player.getDir(),
-            itemBox: this._player.getCopyOfItemBox()
+            itemBox: this._player.getCopyOfItemBox(),
+            wwaData: this._wwaData
         }
     }
     


### PR DESCRIPTION
## 概要
指定した物体・マップIDを指定することによりマップチップ上の画像の座標を取得できます。
PICTURE機能支援関数になります。

* 構文: `GET_IMG_POS_X(parts_id, is_object, is_first_motion)` 

`is_object=0: 物体`
`is_object=1: 背景`

is_first_motion は物体を指定したときのみ有効。
物体パーツは2つの画像で構成されているため、`is_first_motion=0` で1つ目の画像のX/Y座標を、`is_first_motion=2` で2つ目の画像のY座標を取得する。

## 使い方の例
![Screenshot 2024-02-10 at 15-01-58 World Wide Adventure Wing](https://github.com/WWAWing/WWAWing/assets/17096208/67f22306-f3da-41d4-a9a8-84dc26d53355)

スタンダードマップの赤枠で囲った座標の画像座標を取得する例

```
// 物体パーツの画像座標を取得
v[0] = o[2][1];
v[1] = GET_IMG_POS_X(v[0], 0, 0) // 80
v[2] = GET_IMG_POS_Y(v[0], 0, 0) // 440

v[3] = GET_IMG_POS_X(v[0], 0, 1) // 80
v[4] = GET_IMG_POS_Y(v[0], 0, 1) // 480

// 背景パーツの画像座標を取得
v[5] = m[2][1];
v[6] = GET_IMG_POS_X(v[5], 1) // 80
v[7] = GET_IMG_POS_Y(v[5], 1) // 160
```

* 引数省略時の挙動
```
v[0] = o[2][1];
v[1] = GET_IMG_POS_X(v[0], 0) // 80
v[2] = GET_IMG_POS_Y(v[0], 0) // 440

v[1] = GET_IMG_POS_X(v[0]) // 80
v[2] = GET_IMG_POS_Y(v[0]) // 440
```