### PR TITLE
feat: 【WWA Script】 実行元パーツ情報の代入を禁止するように修正

### DIFF
--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -332,7 +332,7 @@ function convertAssignmentExpression(node: Acorn.AssignmentExpression): Wwa.WWAN
           throw new Error("");
         }
       } else if (left.type === "Symbol") {
-        if (left.name === "m" || left.name === "o" || left.name === "v" || left.name === "ITEM") {
+        if (left.name === "m" || left.name === "o" || left.name === "v" || left.name === "ITEM" || left.name === "X" || left.name === "Y" || left.name === "ID" || left.name === "TYPE") {
           throw new Error("このシンボルには代入できません");
         }
         if (left.name === "AT_TOTAL") {

--- a/packages/engine/src/wwa_expression2/wwa.ts
+++ b/packages/engine/src/wwa_expression2/wwa.ts
@@ -32,7 +32,7 @@ export interface UserVariableAssignment {
 
 export interface SpecialParameterAssignment {
   type: "SpecialParameterAssignment";
-  kind: "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "HP" | "HPMAX" | "AT" | "DF" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS";
+  kind: "PX" | "PY" | "HP" | "HPMAX" | "AT" | "DF" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS";
   value: Calcurable;
   operator?: "=" | "+=" | "-=" | "*=" | "/=";
 }


### PR DESCRIPTION
#689 で `X` と `Y` 、 `ID` 、 `TYPE` から実行元パーツ情報を WWA Script で取得できるようになりましたが、この定数に対して代入できるような設計になっていたので修正します。

現在のバージョンでも代入はできないのですが、「未実装の要素です」と出力されていて、あたかも代入で改変できそうな挙動をしていたので、できないようにエラーメッセージの内容と出力経路を変更します。

![image](https://github.com/WWAWing/WWAWing/assets/12381375/969ecc2f-9b05-4154-bd32-bc0832183ad5)

修正後ではこんな感じでエラーが発生します。

![image](https://github.com/WWAWing/WWAWing/assets/12381375/c44fa07f-c39d-474f-94f7-68842162dfc9)

