### PR TITLE
feat(message): WWA Script 実行タイミングの変更

### DIFF
--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -1893,7 +1893,7 @@ export class WWA {
                 //  (this._pages の後尾にシステムメッセージのページが追加されるため)
                 // マクロ実行の結果新たなメッセージが発生するのは稀だが、下記のようなケースが存在する。
                 // - $item マクロ実行後に発生するクリック可能アイテムの初回取得メッセージ: https://github.com/WWAWing/WWAWing/issues/212
-                const executedResult = Node.executeNodes(executingPage.firstNode, executingPage.option.triggerParts);
+                const executedResult = Node.executeNodes(executingPage.firstNode, executingPage.triggerParts);
                 if (executedResult.isError === true) { // true としっかりかかないと型推論が効かない
                     // executeNodes の結果、ゲームオーバーになるなどして、メッセージ処理が中断した場合、メッセージを出さない。
                     this._isLastPage = false;
@@ -1904,12 +1904,12 @@ export class WWA {
                     this._reservedMoveMacroTurn = void 0;
                 }
                 const messageLinesToDisplay = executedResult.messages.filter(line => !line.isEmpty());
-                const isScoreDisplayingPage = Boolean(executingPage.option.scoreOption);
+                const isScoreDisplayingPage = Boolean(executingPage.scoreOption);
 
                 // スコア表示ページ かつ 表示するメッセージがない場合は「スコアを表示します」を表示内容に加える。
                 // システムメッセージ扱いではなく、パーツが表示している扱いになります。
                 if (isScoreDisplayingPage && messageLinesToDisplay.length === 0) {
-                    messageLinesToDisplay.push(this._createSimpleMessage("スコアを表示します。", executingPage.option.triggerParts));
+                    messageLinesToDisplay.push(this._createSimpleMessage("スコアを表示します。", executingPage.triggerParts));
                 }
 
                 // 表示されるメッセージがある場合は、メッセージウィンドウを表示してループから抜ける
@@ -1917,17 +1917,17 @@ export class WWA {
                 if (existsMessageToDisplay) {
                     const message = messageLinesToDisplay.map(line => line.generatePrintableMessage()).join("\n");
                     this._messageWindow.setMessage(message);
-                    this._messageWindow.setYesNoChoice(executingPage.option.showChoice);
+                    this._messageWindow.setYesNoChoice(executingPage.showChoice);
                     this._messageWindow.setPositionByPlayerPosition(
                         this._faces.length !== 0,
                         isScoreDisplayingPage,
-                        executingPage.option.isSystemMessage,
+                        executingPage.isSystemMessage,
                         this._player.getPosition(),
                         this._camera.getPosition()
                     );
                     if (isScoreDisplayingPage) {
-                        this._lastScoreOptions = executingPage.option.scoreOption;
-                        this.updateScore(executingPage.option.scoreOption);
+                        this._lastScoreOptions = executingPage.scoreOption;
+                        this.updateScore(executingPage.scoreOption);
                         this._scoreWindow.show();
                     }
                     this._player.setMessageWaiting();
@@ -3964,7 +3964,12 @@ export class WWA {
     }
 
     private _createSimpleMessage(message: string, triggerParts?: TriggerParts): ParsedMessage {
-        return new ParsedMessage(message, () => this.generateTokenValues(triggerParts))
+        return new ParsedMessage(
+          message,
+          () => this.generateTokenValues(triggerParts),
+          (script: string, triggerParts?: TriggerParts) =>
+            this._execEvalString(script, triggerParts)
+        );
     }
 
     // HACK: private にしたい
@@ -3992,9 +3997,7 @@ export class WWA {
           message,
           { triggerParts, isSystemMessage, showChoice, scoreOption },
           (macroStr: string) => parseMacro(this, triggerParts, macroStr),
-          // HACK: WWA Script の呼び出し順変更が終わったら消せる
-          (scriptStrings: string) =>
-            this._execEvalString(scriptStrings, triggerParts),
+          (script: string, triggerParts?: TriggerParts) => this._execEvalString(script, triggerParts),
           // HACK: expressionParser 依存を打ち切りたい (wwa_expression2 に完全移行できれば嫌でも消えるはず)
           // 型が any になってしまうのであえて bind 使ってません
           (triggerParts: TriggerParts) => this.generateTokenValues(triggerParts)

--- a/packages/engine/src/wwa_message/data/index.ts
+++ b/packages/engine/src/wwa_message/data/index.ts
@@ -1,7 +1,7 @@
 import { PreprocessMacroType } from "../../wwa_data"
 import { Macro } from "../../wwa_macro";
 export { Node, Branch, Junction, LazyEvaluateValue, ParsedMessage, MessageSegments } from "./node";
-export { Page, PageOption } from "./page";
+export { Page, PageGeneratingOption} from "./page";
 
 export type MessageLineType = PreprocessMacroType | "text" | "normalMacro";
 export type MessageLine =

--- a/packages/engine/src/wwa_message/data/node.ts
+++ b/packages/engine/src/wwa_message/data/node.ts
@@ -119,9 +119,11 @@ export class ParsedMessage extends Node {
   private messageSegments: MessageSegments;
   constructor(
     textOrMessageSegments: string | MessageSegments,
-    generateTokenValues: () => TokenValues,
+    generateTokenValues: (triggerParts?: TriggerParts) => TokenValues,
+    private evalScript: (script: string, triggerParts?: TriggerParts) => void,
     public macro?: Macro[],
-    public next?: Node
+    public next?: Node,
+    public script?: string
   ) {
     super(generateTokenValues);
     this.messageSegments = this.parseMessage(textOrMessageSegments);
@@ -163,11 +165,29 @@ export class ParsedMessage extends Node {
     );
   }
 
+  static createEmptyMessage(
+    generateTokenValues: (triggerParts?: TriggerParts) => TokenValues,
+    evalScript: (script: string, triggerParts?: TriggerParts) => void,
+    script?: string
+  ): ParsedMessage {
+    return new ParsedMessage(
+      [],
+      generateTokenValues,
+      evalScript,
+      undefined,
+      undefined,
+      script
+    );
+  }
+
   private parseMessage(message: string | MessageSegments): MessageSegments {
     return typeof message === "string" ? [message] : message;
   }
 
   override execute(triggerParts?: TriggerParts): ParsedMessage[] {
+    if (this.script) {
+      this.evalScript(this.script);
+    }
     this.macro?.forEach((macro) => {
       const result = macro.execute();
       if (result.isGameOver) {

--- a/packages/engine/src/wwa_message/data/page.ts
+++ b/packages/engine/src/wwa_message/data/page.ts
@@ -2,26 +2,22 @@ import type { ScoreOption, TriggerParts } from "../../wwa_data";
 
 import { Node } from "./node";
 
-export interface PageOption {
-  // パーツIDと種別の情報
+export interface Page {
+  /** ページの最初のノード */
+  firstNode?: Node,
+  /** このページが最後のページか */
+  isLastPage: boolean,
+  /** 実行元パーツ情報 */
   triggerParts: TriggerParts;
+  /** システムメッセージかどうか */
   isSystemMessage: boolean;
+  /** 二者択一ページかどうか */
   showChoice: boolean;
-  // score オブジェクトがあるときスコア表示
+  /** オブジェクトがあるときスコア表示ページ */
   scoreOption?: ScoreOption;
 }
 
-export type PartialPageOption = Partial<PageOption>;
-
-export class Page {
-  constructor(
-    public firstNode: Node,
-    public isLastPage: boolean,
-    public option: PartialPageOption
-  ) {}
-
-
-  static createEmptyPage(pageOption: PageOption): Page {
-    return new Page(undefined, true, pageOption);
-  }
-}
+/**
+ * ページ生成のためのオプション
+ */
+export type PageGeneratingOption = Pick<Page, "triggerParts" | "isSystemMessage" | "showChoice" | "scoreOption">;


### PR DESCRIPTION
WWA Script 正式化に向けての最も大きな壁である WWA Script 実行タイミングの変更PRです。
主に以下の観点からの動作確認が必要です

- [x] スコア表示パーツ（メッセージなし）が動く
- [x] スコア表示パーツ（マクロのみ）が動く
- [x] スコア表示パーツ（スクリプトのみ)が動く
  - 挙動としては正しそうですが、MSGを呼んだ場合の挙動はかなり不安定なので今後改善します
  - 以前は空メッセージスコア＋MSGの場合はMSGが無視される挙動だった
- [x] スコア表示パーツ（マクロとスクリプトのみ）が動く
- [x] スコア表示パーツ（通常メッセージ）が動く
- [x] メッセージパーツ（メッセージなし）が動く
- [x] メッセージパーツ（マクロのみ）が動く
- [x] メッセージパーツ（スクリプトのみ）が動く
- [x] メッセージパーツ（マクロとスクリプトのみ）が動く
- [x] メッセージパーツ（通常メッセージ）が動く
- [x] `$if` がある物体パーツでスクリプトが正しく実行される
- [x] ステータス変化パーツで `o[PX][PY]` への代入が正しく動作する