### PR TITLE
fix(make-wwawing-dist): wwa.js の改行コードを CRLF から LF に変更した

### DIFF
--- a/packages/all/scripts/make-wwawing-dist.ts
+++ b/packages/all/scripts/make-wwawing-dist.ts
@@ -103,7 +103,11 @@ export default async function makeDistribution(
                                 }
                                 resolve({
                                     target,
-                                    content: convertLfToCrlf(data.toString("utf8"))
+                                    content: target.endsWith("wwa.js") ?
+                                        // wwa.js は minify されているため、バイト数を少しでも減らすため改行コードLFを維持する
+                                        data.toString("utf8"):
+                                        // それ以外のファイルは Windows のメモ帳(の古い版)で開かれることを想定し改行コードをCRLFとする
+                                        convertLfToCrlf(data.toString("utf8"))
                                 });
                             })
                         })


### PR DESCRIPTION
wwa.js は minify されているので、改行コードがCRLFである必要がないのですが、改行コードがCRLFだとwwa.jsが Windows Defender にトロイの木馬と判定されることがあるため、改行コードをLFに変更します。