### PR TITLE
WWA Script の X/Y/ID/TYPE が機能しない不具合の修正

### DIFF
--- a/packages/engine/src/wwa_message/data/node.ts
+++ b/packages/engine/src/wwa_message/data/node.ts
@@ -186,7 +186,7 @@ export class ParsedMessage extends Node {
 
   override execute(triggerParts?: TriggerParts): ParsedMessage[] {
     if (this.script) {
-      this.evalScript(this.script);
+      this.evalScript(this.script, triggerParts);
     }
     this.macro?.forEach((macro) => {
       const result = macro.execute();


### PR DESCRIPTION
#704 の対応の影響で、 `triggerParts` の渡し忘れで実行元パーツ情報が正しく出力されなかったので修正しました。

## 動作確認

テストマップにて、実行元パーツ情報や位置が正しくセットされていることを確認。

![image](https://github.com/WWAWing/WWAWing/assets/12381375/2085ed93-86e1-4a9d-b75b-52bedfbd5495)
