### PR TITLE
feat: ピクチャ機能の time プロパティの開始時間指定と animTime プロパティの機能を実装

### DIFF
--- a/packages/engine/src/wwa_picture/WWAPicture.ts
+++ b/packages/engine/src/wwa_picture/WWAPicture.ts
@@ -292,6 +292,7 @@ export default class WWAPicutre {
             }
             if (picture.hasAnimation) {
                 picture.updateAnimation();
+                picture.tickAnimTimeStock(frameMs);
                 picture.draw(image, isMainAnimation);
             }
             if (picture.isWaiting()) {

--- a/packages/engine/src/wwa_picture/WWAPicture.ts
+++ b/packages/engine/src/wwa_picture/WWAPicture.ts
@@ -220,6 +220,9 @@ export default class WWAPicutre {
 
     public updateAllPicturesCache(image: HTMLImageElement, isMainAnimation: boolean) {
         this.forEachPictures((picture) => {
+            if (picture.isNotStarted()) {
+                return;
+            }
             picture.draw(image, isMainAnimation);
         })
     }
@@ -241,6 +244,14 @@ export default class WWAPicutre {
         const newFrameValue = WWAPicutre._getNowFrameValue();
         const frameMs = newFrameValue - this._frameTimerValue;
         this.forEachPictures(picture => {
+            if (picture.isNotStarted()) {
+                picture.tickStartTimeStock(frameMs);
+                if (picture.isStartTimeOver()) {
+                    picture.startDisplayTimeStock();
+                } else {
+                    return;
+                }
+            }
             if (picture.hasDisplayTimeStock()) {
                 picture.tickDisplayTimeStock(frameMs);
                 // TODO ネストが深くなってる、そろそろなんとかせねば

--- a/packages/engine/src/wwa_picture/WWAPictureItem.ts
+++ b/packages/engine/src/wwa_picture/WWAPictureItem.ts
@@ -3,7 +3,15 @@ import { PartsType } from "@wwawing/loader";
 import { CacheCanvas } from "../wwa_cgmanager";
 import { Coord, WWAConsts } from "../wwa_data";
 import * as util from "../wwa_util";
-import { adjustPositiveValue, getHorizontalCirclePosition, getHorizontalCorrectionBySizeAnchor, getVerticalCirclePosition, getVerticalCorrectionBySizeAnchor } from "./utils";
+import {
+    getFirstValueFromSingleOrArray,
+    getArrayItemFromSingleOrArray,
+    adjustPositiveValue,
+    getHorizontalCirclePosition,
+    getHorizontalCorrectionBySizeAnchor,
+    getVerticalCirclePosition,
+    getVerticalCorrectionBySizeAnchor
+} from "./utils";
 import { NextPicturePartsInfo } from "./typedef";
 import { WWATimer } from "./WWATimer";
 
@@ -62,6 +70,7 @@ export default class WWAPictureItem {
     private readonly _fade: number;
     private readonly _hasAnimation: boolean;
     
+    private _startTime?: WWATimer;
     private _displayStockTime?: WWATimer;
     private _waitStockTime?: WWATimer;
 
@@ -104,7 +113,15 @@ export default class WWAPictureItem {
 
         this._updatePictureCache();
         
-        this._displayStockTime = WWATimer.createTimerOrArray(properties.time, properties.timeFrame);
+        // TODO タイマーがまだ開始していない状態を定義したい。
+        this._displayStockTime = WWATimer.createTimer(
+            getFirstValueFromSingleOrArray(properties.time),
+            getFirstValueFromSingleOrArray(properties.timeFrame)
+        );
+        this._startTime = WWATimer.createTimer(
+            getArrayItemFromSingleOrArray(properties.time, 1),
+            getArrayItemFromSingleOrArray(properties.timeFrame, 1)
+        );
         this._waitStockTime = WWATimer.createTimer(properties.wait, properties.waitFrame);
         
         // Canvas の ctx を色々いじる
@@ -243,6 +260,10 @@ export default class WWAPictureItem {
             this._totalHeight,
             this._anchor
         );
+    }
+
+    public isNotStarted() {
+        return this._startTime !== undefined && !this._startTime.isTimeOver();
     }
 
     public hasDisplayTimeStock() {

--- a/packages/engine/src/wwa_picture/WWAPictureItem.ts
+++ b/packages/engine/src/wwa_picture/WWAPictureItem.ts
@@ -123,6 +123,13 @@ export default class WWAPictureItem {
             getArrayItemFromSingleOrArray(properties.timeFrame, 1)
         );
         this._waitStockTime = WWATimer.createTimer(properties.wait, properties.waitFrame);
+
+        if (this._startTime) {
+            this._startTime.start();
+        } else if (this._displayStockTime) {
+            this._displayStockTime.start();
+        }
+        this._waitStockTime?.start();
         
         // Canvas の ctx を色々いじる
         this._canvas.ctx.globalAlpha = WWAPictureItem._roundPercentage(this._opacity) / 100;
@@ -270,6 +277,10 @@ export default class WWAPictureItem {
         return this._displayStockTime !== undefined && !this._displayStockTime.isTimeOver();
     }
 
+    public tickStartTimeStock(frameMs: number) {
+        this._startTime?.tick(frameMs);
+    }
+
     public tickDisplayTimeStock(frameMs: number) {
         this._displayStockTime?.tick(frameMs);
     }
@@ -279,11 +290,19 @@ export default class WWAPictureItem {
     }
 
     public isDeadlineOver() {
-        return this._displayStockTime.isTimeOver();
+        return this._displayStockTime && this._displayStockTime.isTimeOver();
+    }
+
+    public isStartTimeOver() {
+        return !this._startTime || this._startTime.isTimeOver();
     }
 
     public isWaiting() {
         return this._waitStockTime && !this._waitStockTime.isTimeOver();
+    }
+
+    public startDisplayTimeStock() {
+        this._displayStockTime.start();
     }
 
     public clearCanvas() {

--- a/packages/engine/src/wwa_picture/WWATimer.ts
+++ b/packages/engine/src/wwa_picture/WWATimer.ts
@@ -22,17 +22,6 @@ export class WWATimer {
             return new WWATimer(frameTimeValue, "frame");
         }
     }
-    
-    private static _getTimeValue (value: PictureProperties["time"] | PictureProperties["timeFrame"]) {
-        return Array.isArray(value) ? value[0] : value;
-    }
-
-    public static createTimerOrArray(
-        msTimeValue?: PictureProperties["time"],
-        frameTimeValue?: PictureProperties["timeFrame"]
-    ) {
-        return WWATimer.createTimer(this._getTimeValue(msTimeValue), this._getTimeValue(frameTimeValue));
-    }
 
     public tick(frameMs: number) {
         // タイムオーバーの場合は、余計な処理を回避するために無効にする

--- a/packages/engine/src/wwa_picture/WWATimer.ts
+++ b/packages/engine/src/wwa_picture/WWATimer.ts
@@ -8,6 +8,7 @@ type TimeType = "milisecond" | "frame";
 export class WWATimer {
 
     private _timer = 0;
+    private _enabled = false;
 
     constructor(
         private _limitTime: number,
@@ -21,11 +22,16 @@ export class WWATimer {
         } else if (frameTimeValue) {
             return new WWATimer(frameTimeValue, "frame");
         }
+        return undefined;
+    }
+
+    public start() {
+        this._enabled = true;
     }
 
     public tick(frameMs: number) {
         // タイムオーバーの場合は、余計な処理を回避するために無効にする
-        if (this.isTimeOver()) {
+        if (!this._enabled || this.isTimeOver()) {
             return;
         }
         switch (this._timeType) {

--- a/packages/engine/src/wwa_picture/utils.ts
+++ b/packages/engine/src/wwa_picture/utils.ts
@@ -144,6 +144,26 @@ export const convertVariablesFromRawRegistry = (registry: RawPictureRegistry, to
     };
 };
 
+/**
+ * 配列の場合は最初の値を取得します。単体の値はそのまま取得します。
+ */
+export const getFirstValueFromSingleOrArray = <T>(value: T | T[]) => {
+    if (Array.isArray(value)) {
+        return value[0];
+    }
+    return value;
+};
+
+/**
+ * 配列か単体の値かわからない値から項目を取得します。配列以外の場合は undefined を返します。
+ */
+export const getArrayItemFromSingleOrArray = <T>(value: T | T[], index: number) => {
+    if (!Array.isArray) {
+        return undefined;
+    }
+    return value[index];
+};
+
 export const adjustPositiveValue = (value: number) => {
     if (value < 0) {
         return 0;

--- a/packages/engine/src/wwa_picture/utils.ts
+++ b/packages/engine/src/wwa_picture/utils.ts
@@ -158,7 +158,7 @@ export const getFirstValueFromSingleOrArray = <T>(value: T | T[]) => {
  * 配列か単体の値かわからない値から項目を取得します。配列以外の場合は undefined を返します。
  */
 export const getArrayItemFromSingleOrArray = <T>(value: T | T[], index: number) => {
-    if (!Array.isArray) {
+    if (!Array.isArray(value)) {
         return undefined;
     }
     return value[index];


### PR DESCRIPTION
- #708 で書いてあった「`time` プロパティを複数記載できるようにしましたが、2番目の効力は今のところ実装していません。」の実装対応を行います。
- `animTime` プロパティの機能を実装します。

## `animTime` プロパティについて
```
{
  animTime: [100, 200],
}
```

アニメーションの実行時間を指定します。ピクチャ生成時にカウントが始まり、一つ目の値を過ぎるとアニメーションが開始され、二つ目の値を過ぎるとアニメーションが止まります。

- `time` プロパティとは開始と終了の関係が逆です。取り扱いにご注意ください。
- `time` プロパティの開始時間前で非表示の間でもカウントは始まっています。例えば下記のような指定方法では、アニメーションは動きません。
    ```
    {
      time: [1000, 100], // 100ms でピクチャ表示、 1100ms でピクチャ消去
      animTime: [10, 50] // 10ms でアニメーション開始、 50ms でアニメーション終了
    }
    ```
- 一つ目の値が二つ目よりも小さい場合は、アニメーションは動きません。うんともすんとも言いませんが、逆手に利用して、変数制御で条件付きでアニメーションを起こさない仕掛けを作ることはできます。
    ```
    {
      animTime: [100, 50], // これは動きません
    }
    ```
- フレーム時間版もあります。 `animTimeFrame` でどうぞご活用ください。スネークケースで `anim_time_frame` でも書けます。