### PR TITLE
【ピクチャ機能】テキストの描画基準をテキスト上端に変更する

### DIFF
--- a/packages/engine/src/wwa_picture/WWAPictureItem.ts
+++ b/packages/engine/src/wwa_picture/WWAPictureItem.ts
@@ -128,6 +128,7 @@ export default class WWAPictureItem {
         // Canvas の ctx を色々いじる
         this._canvas.ctx.globalAlpha = WWAPictureItem._roundPercentage(this._opacity) / 100;
         this._canvas.ctx.font = WWAPictureItem._getFontValue(properties);
+        this._canvas.ctx.textBaseline = "top";
         if (properties.textAlign) {
             this._canvas.ctx.textAlign = WWAPictureItem._convertTextAlign(properties.textAlign);
         }


### PR DESCRIPTION
**仕様変更が発生します。**

現在の `text` プロパティの描画位置はテキストのベースラインを基準としています。アルファベットをメインに使用する環境では違和感はないですが、日本語では馴染みがなく、思った通りに描画できない（背景にステータス枠を使用して〜、テキストはその左上から余白を考慮してこのくらいにして〜、を想像しながら設定しにくい）ので、描画位置の基準をテキスト上端に変更します。

普通にテキストだけ描画している場合、位置がちょっとズレるので問題はないと思いますが、テキストとその背景を同時に描画している場合は、テキストが下にずれ込むことになると思います。適宜修正をお願いします。

```
PICTURE(1, {
  pos: [100, 100],
  text: "hogehoge",
  img: [1, 2],
});
```

こんな感じに動きます。

![image](https://github.com/WWAWing/WWAWing/assets/12381375/6e1c89bc-efbb-4068-8d1e-ca1d8c45924a)