### PR TITLE
【ピクチャ機能】プレイヤーの画面内座標を算出する PLAYER_PX/PY を実装

### DIFF
--- a/packages/engine/src/wwa_expression2/__tests__/symbols-test.ts
+++ b/packages/engine/src/wwa_expression2/__tests__/symbols-test.ts
@@ -1,0 +1,35 @@
+import { getPlayerCoordPx, getPlayerCoordPy } from "../symbols";
+
+describe("symbols", () => {
+    describe("getPlayerCoordPx", () => {
+        test("現在座標からプレイヤーのピクセル座標を算出する (10以上)", () => {
+            expect(getPlayerCoordPx(19)).toBe(360);
+        });
+        test("現在座標からプレイヤーのピクセル座標を算出する (10未満)", () => {
+            expect(getPlayerCoordPx(3)).toBe(120);
+        });
+        test("画面の端にいる場合で、左端にいる場合は左端のピクセル座標を算出する", () => {
+            expect(getPlayerCoordPx(10)).toBe(0);
+        });
+        test("画面の端にいる場合で、右端にいる場合は右端のピクセル座標を算出する", () => {
+            expect(getPlayerCoordPx(20)).toBe(400);
+        });
+    });
+    describe("getPlayerCoordPy", () => {
+        test("現在座標からプレイヤーのピクセル座標を算出する (10以上)", () => {
+            expect(getPlayerCoordPy(96)).toBe(240);
+        });
+        test("現在座標からプレイヤーのピクセル座標を算出する (10未満)", () => {
+            expect(getPlayerCoordPy(5)).toBe(200);
+        });
+        test("現在座標からプレイヤーのピクセル座標を算出する", () => {
+            expect(getPlayerCoordPy(96)).toBe(240);
+        });
+        test("画面の端にいる場合で、上端にいる場合は上端のピクセル座標を算出する", () => {
+            expect(getPlayerCoordPy(30)).toBe(0);
+        });
+        test("画面の端にいる場合で、下端にいる場合は下端のピクセル座標を算出する", () => {
+            expect(getPlayerCoordPy(40)).toBe(400);
+        });
+    });
+});

--- a/packages/engine/src/wwa_expression2/__tests__/symbols-test.ts
+++ b/packages/engine/src/wwa_expression2/__tests__/symbols-test.ts
@@ -3,33 +3,30 @@ import { getPlayerCoordPx, getPlayerCoordPy } from "../symbols";
 describe("symbols", () => {
     describe("getPlayerCoordPx", () => {
         test("現在座標からプレイヤーのピクセル座標を算出する (10以上)", () => {
-            expect(getPlayerCoordPx(19)).toBe(360);
+            expect(getPlayerCoordPx(19, 10)).toBe(360);
         });
         test("現在座標からプレイヤーのピクセル座標を算出する (10未満)", () => {
-            expect(getPlayerCoordPx(3)).toBe(120);
+            expect(getPlayerCoordPx(3, 0)).toBe(120);
         });
         test("画面の端にいる場合で、左端にいる場合は左端のピクセル座標を算出する", () => {
-            expect(getPlayerCoordPx(10)).toBe(0);
+            expect(getPlayerCoordPx(10, 10)).toBe(0);
         });
         test("画面の端にいる場合で、右端にいる場合は右端のピクセル座標を算出する", () => {
-            expect(getPlayerCoordPx(20)).toBe(400);
+            expect(getPlayerCoordPx(20, 10)).toBe(400);
         });
     });
     describe("getPlayerCoordPy", () => {
         test("現在座標からプレイヤーのピクセル座標を算出する (10以上)", () => {
-            expect(getPlayerCoordPy(96)).toBe(240);
+            expect(getPlayerCoordPy(96, 90)).toBe(240);
         });
         test("現在座標からプレイヤーのピクセル座標を算出する (10未満)", () => {
-            expect(getPlayerCoordPy(5)).toBe(200);
-        });
-        test("現在座標からプレイヤーのピクセル座標を算出する", () => {
-            expect(getPlayerCoordPy(96)).toBe(240);
+            expect(getPlayerCoordPy(5, 0)).toBe(200);
         });
         test("画面の端にいる場合で、上端にいる場合は上端のピクセル座標を算出する", () => {
-            expect(getPlayerCoordPy(30)).toBe(0);
+            expect(getPlayerCoordPy(30, 30)).toBe(0);
         });
         test("画面の端にいる場合で、下端にいる場合は下端のピクセル座標を算出する", () => {
-            expect(getPlayerCoordPy(40)).toBe(400);
+            expect(getPlayerCoordPy(40, 30)).toBe(400);
         });
     });
 });

--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -349,6 +349,8 @@ function convertAssignmentExpression(node: Acorn.AssignmentExpression): Wwa.WWAN
           left.name === "Y" ||
           left.name === "ID" ||
           left.name === "TYPE" ||
+          left.name === "PLAYER_PX" ||
+          left.name === "PLAYER_PY" ||
           left.name === "MOVE_SPEED" ||
           left.name === "MOVE_FRAME_TIME"
         ) {
@@ -494,6 +496,8 @@ function convertIdentifer(node: Acorn.Identifier): Wwa.Symbol | Wwa.Literal {
     case "ENEMY_HP":
     case "ENEMY_AT":
     case "ENEMY_DF":
+    case "PLAYER_PX":
+    case "PLAYER_PY":
     case "MOVE_SPEED":
     case "MOVE_FRAME_TIME":
       return {

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -1017,9 +1017,9 @@ export class EvalCalcWwaNode {
         // 戦闘予測の場合は戦闘予測用HPで計算       
         return this.generator.state.battleDamageCalculation?.estimatingParams?.enemyStatus.gold ?? (typeof enemyStatus === 'number'? -1 : enemyStatus.gold);
       case 'PLAYER_PX':
-        return getPlayerCoordPx(gameStatus.playerCoord.x);
+        return getPlayerCoordPx(gameStatus.playerCoord.x, gameStatus.cameraCoord.x);
       case 'PLAYER_PY':
-        return getPlayerCoordPy(gameStatus.playerCoord.y);
+        return getPlayerCoordPy(gameStatus.playerCoord.y, gameStatus.cameraCoord.y);
       case 'MOVE_SPEED':
         return speedList[gameStatus.gameSpeedIndex];
       case 'MOVE_FRAME_TIME':

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -3,6 +3,7 @@ import { BattleEstimateParameters, Coord, Face, MacroStatusIndex, PartsType, Pos
 import { WWA } from "../wwa_main";
 import * as Wwa from "./wwa";
 import { PARTS_TYPE_LIST } from "./utils";
+import { getPlayerCoordPx, getPlayerCoordPy } from "./symbols";
 
 export class EvalCalcWwaNodeGenerator {
   wwa: WWA;
@@ -1015,6 +1016,10 @@ export class EvalCalcWwaNode {
       case 'ENEMY_GD':
         // 戦闘予測の場合は戦闘予測用HPで計算       
         return this.generator.state.battleDamageCalculation?.estimatingParams?.enemyStatus.gold ?? (typeof enemyStatus === 'number'? -1 : enemyStatus.gold);
+      case 'PLAYER_PX':
+        return getPlayerCoordPx(gameStatus.playerCoord.x);
+      case 'PLAYER_PY':
+        return getPlayerCoordPy(gameStatus.playerCoord.y);
       case 'MOVE_SPEED':
         return speedList[gameStatus.gameSpeedIndex];
       case 'MOVE_FRAME_TIME':

--- a/packages/engine/src/wwa_expression2/symbols/index.ts
+++ b/packages/engine/src/wwa_expression2/symbols/index.ts
@@ -1,0 +1,4 @@
+export {
+    getPlayerCoordPx,
+    getPlayerCoordPy
+} from "./player_coord_pixel";

--- a/packages/engine/src/wwa_expression2/symbols/player_coord_pixel.ts
+++ b/packages/engine/src/wwa_expression2/symbols/player_coord_pixel.ts
@@ -1,0 +1,9 @@
+import { WWAConsts } from "../../wwa_data";
+
+export const getPlayerCoordPx = (playerX: number) => {
+    return (playerX % (WWAConsts.H_PARTS_NUM_IN_WINDOW - 1)) * WWAConsts.CHIP_SIZE;
+};
+
+export const getPlayerCoordPy = (playerY: number) => {
+    return (playerY % (WWAConsts.V_PARTS_NUM_IN_WINDOW - 1)) * WWAConsts.CHIP_SIZE;
+};

--- a/packages/engine/src/wwa_expression2/symbols/player_coord_pixel.ts
+++ b/packages/engine/src/wwa_expression2/symbols/player_coord_pixel.ts
@@ -1,9 +1,23 @@
 import { WWAConsts } from "../../wwa_data";
 
-export const getPlayerCoordPx = (playerX: number) => {
-    return (playerX % (WWAConsts.H_PARTS_NUM_IN_WINDOW - 1)) * WWAConsts.CHIP_SIZE;
+/**
+ * 画面内のプレイヤーの位置をX座標で算出します。
+ * 画面端にプレイヤーがいる場合は、カメラ座標 {@link cameraX} に基づいて判別します。
+ * @param playerX プレイヤーのマップ内のX座標
+ * @param cameraX ゲームのカメラで、一番左のマスの座標 (例えば {@link playerX} が `128` の場合、 `120`)
+ * @returns 画面内のプレイヤーのX座標。
+ */
+export const getPlayerCoordPx = (playerX: number, cameraX: number) => {
+    return (playerX - cameraX) * WWAConsts.CHIP_SIZE;
 };
 
-export const getPlayerCoordPy = (playerY: number) => {
-    return (playerY % (WWAConsts.V_PARTS_NUM_IN_WINDOW - 1)) * WWAConsts.CHIP_SIZE;
+/**
+ * 画面内のプレイヤーの位置をY座標で算出します。
+ * 画面端にプレイヤーがいる場合は、カメラ座標 {@link cameraY} に基づいて判別します。
+ * @param playerY プレイヤーのマップ内のY座標
+ * @param cameraY ゲームのカメラで、一番下のマスの座標 (例えば {@link playerY} が `256` の場合、 `250`)
+ * @returns 画面内のプレイヤーのY座標。
+ */
+export const getPlayerCoordPy = (playerY: number, cameraY: number) => {
+    return (playerY - cameraY) * WWAConsts.CHIP_SIZE;
 };

--- a/packages/engine/src/wwa_expression2/wwa.ts
+++ b/packages/engine/src/wwa_expression2/wwa.ts
@@ -51,7 +51,7 @@ export interface BinaryOperation {
 
 export interface Symbol {
   type: "Symbol";
-  name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD" | "MOVE_SPEED" | "MOVE_FRAME_TIME";
+  name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD" | "PLAYER_PX" | "PLAYER_PY" | "MOVE_SPEED" | "MOVE_FRAME_TIME";
 }
 
 export interface Array1D {

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -6753,6 +6753,7 @@ font-weight: bold;
             userVars: this._userVar.numbered,
             playerCoord: this._player.getPosition().getPartsCoord(),
             playerDirection: this._player.getDir(),
+            cameraCoord: this._camera.getPosition().getPartsCoord(),
             itemBox: this._player.getCopyOfItemBox(),
             gameSpeedIndex: this._player.getSpeedIndex(),
             // TODO ステータスが変わっても更新されていない？


### PR DESCRIPTION
**WWA Script の定数機能追加ですが、マージ先はピクチャ機能になります！！**

現在のプレイヤーの座標は `PX` と `PY` で算出できますが、ピクチャ機能で使用した場合、画面下端あるいは画面右端にプレイヤーがいる場合は正確に算出できない問題があります。

```js
{
  // 画面右端あるいは下端にいるとなぜか 0 になる
  pos: ([PX % 10) * 40, (PY % 10) * 40],
}
```

これは画面端はプレイヤーの座標は同じだけど、プレイヤーの描画場所が異なるためです。
この場合はカメラ座標を算出すれば良いんですが、ほとんどの場合プレイヤーの画面内座標を使用したいため、プレイヤーの画面内座標を算出する定数を実装しました。
（カメラ座標も必要であれば実装するつもりです）

```js
{
  pos: [PLAYER_PX, PLAYER_PY],
}
```

こんな感じで算出されます。

![wwawing_player_screen_coord](https://github.com/WWAWing/WWAWing/assets/12381375/f722a34a-a35d-4685-81d0-f356a578d4fd)

WWAeval で言う `ToPixelXY` 関数相当の機能をします。

## 動作確認
- [x] マップ画面の真ん中にいる場合、プレイヤーの画面内座標が正しく算出されている（マップの一番左上の画面にいる場合）
- [x] マップ画面の真ん中にいる場合、プレイヤーの画面内座標が正しく算出されている（マップの一番左上以外の画面にいる場合）
- [x] マップ画面の左端にいる場合、プレイヤーの画面内座標 (`0`) が正しく算出されている
- [x] マップ画面の上端にいる場合、プレイヤーの画面内座標 (`0`) が正しく算出されている
- [x] マップ画面の右端にいる場合、プレイヤーの画面内座標 (`400`) が正しく算出されている
- [x] マップ画面の下端にいる場合、プレイヤーの画面内座標 (`400`) が正しく算出されている