### PR TITLE
【ピクチャ機能】 text プロパティで数値形式が使用できない問題の修正

### DIFF
--- a/packages/engine/src/wwa_picture/utils.ts
+++ b/packages/engine/src/wwa_picture/utils.ts
@@ -45,11 +45,14 @@ const validatePropertyValue = (key: string, value: unknown): boolean => {
             break;
         }
         case "string":
+            // TODO "text" プロパティのように文字列も数値も受け付けるプロパティと、 "textAlign" プロパティのように文字列しか受け付けないプロパティで種類を分けたい
             if (typeof value !== "string") {
-                if (typeof value !== "number") {
+                if (typeof value === "number") {
+                    console.warn(`プロパティ ${key} は文字列形式を推奨しています。実際に入った値は ${value} です。`);
+                } else {
                     console.warn(`プロパティ ${key} では文字列形式である必要があります。実際に入った値は ${value} です。`);
+                    return false;
                 }
-                return false;
             }
     }
     return true;


### PR DESCRIPTION
`text` プロパティに数値形式を使用すると `Uncaught TypeError: t.split is not a function` とエラーで止まる不具合が発生したので修正しました。

原因はプロパティを適切な形式に変換する過程の前でバリデーションが行われ、そのバリデーションで弾かれるとそのままの値が使用されていたことでした。
そして `text` プロパティでは改行対応で `"\n"` 区切りで各行分割していたので、その処理に引っかかってエラーになりました。

今回の修正は `text` プロパティに焦点を当てていますが、 `textAlign` などの文字列形式のプロパティも数値形式を文字列形式に変換するようになっているので、安定して動作できると思います。

なお、文字列形式のプロパティに数値形式が入った場合、下図のように一応警告が出てきます。

<img width="468" alt="スクリーンショット 2024-06-06 215703" src="https://github.com/WWAWing/WWAWing/assets/12381375/6c0518ea-df79-46f3-9b22-39343e2ecfb1">

将来は文字列も数値も容認できるプロパティと、文字列しか認めないプロパティに区分けしようかなと考えています。

↓ 検証に使用した WWA Script のコード
```
PICTURE(1,{
  pos: [100, 100],
  text: 123,
  font: "20px sans-serif",
  lineHeight: 20,
  textAlign: "center"
})
```