### PR TITLE
feat(WWA Script): WWAのカメラ座標を取得するシンボルとカメラ移動に発生するイベント関数を追加

### DIFF
--- a/packages/assets/script/defined.js
+++ b/packages/assets/script/defined.js
@@ -90,7 +90,7 @@ function CALL_MOVE() {
  * カメラ画面が動く度に呼ばれる関数
  * CX と CY でカメラ画面の左上の座標が取得できます
  */
-function CALL_CAMERAMOVE() {
+function CALL_CAMERA_MOVE() {
 }
 
 /**

--- a/packages/assets/script/defined.js
+++ b/packages/assets/script/defined.js
@@ -87,6 +87,13 @@ function CALL_MOVE() {
 }
 
 /**
+ * カメラ画面が動く度に呼ばれる関数
+ * CX と CY でカメラ画面の左上の座標が取得できます
+ */
+function CALL_CAMERAMOVE() {
+}
+
+/**
  * 速度変更時に呼ばれる関数
  */
 function CALL_CHANGE_SPEED() {

--- a/packages/engine/src/wwa_camera.ts
+++ b/packages/engine/src/wwa_camera.ts
@@ -26,6 +26,11 @@ export class Camera {
         return this._isResetting;
     }
 
+    /**
+     * カメラ座標を取得します。座標はプレイヤーのいる画面の一番左上のマスの座標が使用されます。
+     * 例えばプレイヤーの座標が X: 15, Y: 23 にいる場合、返却値は X: 10, Y: 20 となります。
+     * @returns プレイヤーのいるカメラ画面の一番左上のマスの座標
+     */
     public getPosition(): Position {
         return this._position;
     }

--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -332,7 +332,7 @@ function convertAssignmentExpression(node: Acorn.AssignmentExpression): Wwa.WWAN
           throw new Error("");
         }
       } else if (left.type === "Symbol") {
-        if (left.name === "m" || left.name === "o" || left.name === "v" || left.name === "ITEM" || left.name === "X" || left.name === "Y" || left.name === "ID" || left.name === "TYPE") {
+        if (left.name === "m" || left.name === "o" || left.name === "v" || left.name === "ITEM" || left.name === "X" || left.name === "Y" || left.name === "ID" || left.name === "TYPE" || left.name === "CX" || left.name === "CY") {
           throw new Error("このシンボルには代入できません");
         }
         if (left.name === "AT_TOTAL") {
@@ -455,6 +455,8 @@ function convertIdentifer(node: Acorn.Identifier): Wwa.Symbol | Wwa.Literal {
     case "TYPE":
     case "PX":
     case "PY":
+    case "CX":
+    case "CY":
     case "v":
     case "HP":
     case "HPMAX":

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -1017,6 +1017,10 @@ export class EvalCalcWwaNode {
         return gameStatus.playerCoord.x;
       case "PY":
         return gameStatus.playerCoord.y;
+      case "CX":
+        return gameStatus.cameraCoord.x;
+      case "CY":
+        return gameStatus.cameraCoord.y;
       case "AT":
         return gameStatus.bareStatus.strength;
       case "AT_TOTAL":

--- a/packages/engine/src/wwa_expression2/wwa.ts
+++ b/packages/engine/src/wwa_expression2/wwa.ts
@@ -52,7 +52,7 @@ export interface BinaryOperation {
 
 export interface Symbol {
   type: "Symbol";
-  name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD";
+  name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "CX" | "CY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD";
 }
 
 export interface Array1D {

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -1275,11 +1275,11 @@ export class WWA {
     }
 
     /**
-     * WWA Script のユーザー定義独自関数 "CALL_CAMERAMOVE" を実行します。
+     * WWA Script のユーザー定義独自関数 "CALL_CAMERA_MOVE" を実行します。
      * カメラ画面の切り替わりが終わった時に実行されます。
      */
     public callCameraMoveUserDefineFunction() {
-        const cameraMoveFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALL_CAMERAMOVE"];
+        const cameraMoveFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALL_CAMERA_MOVE"];
         if (cameraMoveFunc) {
             this.evalCalcWwaNodeGenerator.evalWwaNode(cameraMoveFunc);
         }

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -1274,6 +1274,17 @@ export class WWA {
         }
     }
 
+    /**
+     * WWA Script のユーザー定義独自関数 "CALL_CAMERAMOVE" を実行します。
+     * カメラ画面の切り替わりが終わった時に実行されます。
+     */
+    public callCameraMoveUserDefineFunction() {
+        const cameraMoveFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALL_CAMERAMOVE"];
+        if (cameraMoveFunc) {
+            this.evalCalcWwaNodeGenerator.evalWwaNode(cameraMoveFunc);
+        }
+    }
+
     public getUserScript(functionName: string): WWANode | null {
         return this.userDefinedFunctions && this.userDefinedFunctions[functionName] || null;
     }

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -6645,6 +6645,7 @@ font-weight: bold;
             userVars: this._userVar.numbered,
             playerCoord: this._player.getPosition().getPartsCoord(),
             playerDirection: this._player.getDir(),
+            cameraCoord: this._camera.getPosition().getPartsCoord(),
             itemBox: this._player.getCopyOfItemBox(),
             wwaData: this._wwaData
         }

--- a/packages/engine/src/wwa_parts_player.ts
+++ b/packages/engine/src/wwa_parts_player.ts
@@ -125,6 +125,8 @@ export class Player extends PartsObject {
             }
             if (this._isOnCameraStopPosition()) {
                 this._state = PlayerState.CONTROLLABLE;
+                // カメラ画面が動き終わった際にユーザー定義独自関数を呼び出す
+                this._wwa.callCameraMoveUserDefineFunction();
             }
         } else if (this._state === PlayerState.MOVING) {
             try {


### PR DESCRIPTION
https://github.com/user-attachments/assets/a7548e48-3353-4cd5-95bc-6162a3ea2dfd

# 新機能解説

## シンボル "CX" と "CY"
それぞれカメラ画面の左上端の座標を X, Y で取得します。
例えばプレイヤーが X: 15, Y: 23 とした場合、 X: 10, Y: 20 で取得します。

このシンボルに代入はできません。

## ユーザー定義イベント関数 "CALL_CAMERAMOVE"
カメラ画面が移動し終わった時に実行されるユーザー定義イベント関数です。
この場合 "CX" と "CY" を使用すると、移動後の座標で取得します。

ピクチャ機能と併用することで、特定のパーツ上にのみ描画する動きが（一応）作れるようになります。