### PR TITLE
fix(WWA Script): WWA Script付きの完全版にScript関連のファイルを含める

### DIFF
--- a/packages/all/scripts/make-wwawing-dist.ts
+++ b/packages/all/scripts/make-wwawing-dist.ts
@@ -24,6 +24,7 @@ export default async function makeDistribution(
     if (!isUpdate) {
         shell.mkdir("-p", path.join(destBasePath, "mapdata"));
         shell.mkdir("-p", path.join(destBasePath, "mapdata", "audio"));
+        shell.mkdir("-p", path.join(destBasePath, "mapdata", "script"));
         shell.mkdir("-p", path.join(destBasePath, "mapdata", "backup"));
     }
     let tasks = [];
@@ -54,6 +55,8 @@ export default async function makeDistribution(
             copy("debug-server", path.join("bin", "LICENSE"), "mapdata"),
             copy("styles", path.join("output", "*.css"), "mapdata"),
             copy("assets", path.join("vars", "*.json"), "mapdata"),
+            copy("assets", path.join("script", "script_file_list.json"), "mapdata"),
+            copy("assets", path.join("script", "*.js"), path.join("mapdata", "script")),
         ];
     }
     await Promise.all(tasks);

--- a/packages/all/scripts/make-wwawing-dist.ts
+++ b/packages/all/scripts/make-wwawing-dist.ts
@@ -55,7 +55,7 @@ export default async function makeDistribution(
             copy("debug-server", path.join("bin", "LICENSE"), "mapdata"),
             copy("styles", path.join("output", "*.css"), "mapdata"),
             copy("assets", path.join("vars", "*.json"), "mapdata"),
-            copy("assets", path.join("script", "script_file_list.json"), "mapdata"),
+            copy("assets", path.join("script", "script_file_list.json"), path.join("mapdata", "script")),
             copy("assets", path.join("script", "*.js"), path.join("mapdata", "script")),
         ];
     }


### PR DESCRIPTION
不安定版の完全版に WWA Script を使用する上で必要になる以下のファイルが欠けていたため追加しました。

- script_file_list.json
- script/index.js
- script/defined.js

ピクチャ機能では上記のファイルがないとテストマップの一部サンプルが動かないため、このプルリクエストマージ後はピクチャ機能のブランチ (#682) にも取り入れます。

- [x] 生成した完全版を展開し、 wwa-server で WWA Wing を動かすと WWA Script のファイルが正しく動く

https://github.com/user-attachments/assets/28164ff3-07c7-4d23-926d-4059540eb21e