### PR TITLE
カバー未指定だとWWAが起動しない問題の修正

### DIFF
--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -6849,7 +6849,7 @@ function start() {
             return mes;             // Gecko and WebKit
         }
     });
-    var titleImgName = util.$id("wwa-wrapper").getAttribute("data-wwa-title-img");
+    const titleImgName = util.$id("wwa-wrapper").getAttribute("data-wwa-title-img");
     const virtualPadAttribute = util.$id("wwa-wrapper").getAttribute("data-wwa-virtualpad-enable");
     const virtualPadEnable = virtualPadAttribute !== null && virtualPadAttribute.match(/^true$/i) !== null;
     inject(<HTMLDivElement>util.$id("wwa-wrapper"), titleImgName, virtualPadEnable);
@@ -6906,7 +6906,8 @@ function start() {
         {
             mapdata: mapFileName,
             urlGateEnable: urlgateEnabled,
-            titleImg: titleImgName,
+            // WWA のコンストラクターはカバー画像未指定の場合は undefined と扱う
+            titleImg: titleImgName ?? undefined,
             audioDir: audioDirectory,
             classicModeEnable: classicModeEnabled,
             itemEffectEnable: itemEffectEnabled,


### PR DESCRIPTION
`data-wwa-title-img` が未指定だと指定していると誤判定してしまって起動しない問題が発生していました。

WWA コンストラクター内部では `undefined` の一方で、 start() 関数では `null` と扱っていて、比較も `===` だったため判別に失敗していました。

- [x] `data-wwa-title-img` が未指定の状態だとちゃんと Welcome to WWA Wing! 表示で起動する
- [x] `data-wwa-title-img` を指定している状態だと指定したカバー画像で起動する