### PR TITLE
CALL_BGM_ENDを実装

### DIFF
--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -536,6 +536,7 @@ function convertIdentifer(node: Acorn.Identifier): Wwa.Symbol | Wwa.Literal {
     case "j":
     case "k":
     case "LOOPLIMIT":
+    case "SOUND_ID":
     case "ITEM_ID":
     case "ITEM_POS":
     case "ENEMY_HP":

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -41,6 +41,11 @@ export class EvalCalcWwaNodeGenerator {
       /** 使用・取得したアイテムの位置 */
       itemPos1To12?: number
     }
+    /** サウンド取得時ならオブジェクトあり, さもなくば undefined. */
+    readonly earnedSound?: {
+      /** 再生サウンドのID */
+      soundId?: number,
+    }
     /** 戦闘ダメージのための計算ならオブジェクトあり, さもなくば undefined */
     readonly battleDamageCalculation?: {
       /** 計算結果に中断が含まれている */
@@ -72,6 +77,13 @@ export class EvalCalcWwaNodeGenerator {
 
   public clearTemporaryState() {
     this.state = { ...this.state, triggerParts: undefined, messagePageAdditionalQueue: [] };
+  }
+  /**
+   * サウンド関連のReadOnly値をセットする
+   * @param sound_id 再生したサウンドのID
+   */
+  public setEarnedSound(soundId: number) {
+    this.state = { ...this.state, earnedSound: { soundId } };
   }
 
   /**
@@ -1249,6 +1261,8 @@ export class EvalCalcWwaNode {
         return this.for_id.k;
       case 'LOOPLIMIT':
         return this.generator.loop_limit;
+      case 'SOUND_ID':
+        return this.generator.state.earnedSound?.soundId ?? -1;
       case 'ITEM_ID':
         return this.generator.state.earnedItem?.partsId ?? -1;
       case 'ITEM_POS':

--- a/packages/engine/src/wwa_expression2/wwa.ts
+++ b/packages/engine/src/wwa_expression2/wwa.ts
@@ -39,7 +39,7 @@ export interface LoopPointerAssignment {
 
 export interface SpecialParameterAssignment {
   type: "SpecialParameterAssignment";
-  kind: "PX" | "PY" | "HP" | "HPMAX" | "AT" | "DF" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS";
+  kind: "PX" | "PY" | "HP" | "HPMAX" | "AT" | "DF" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "SOUND_ID" ;
   value: Calcurable;
   operator?: "=" | "+=" | "-=" | "*=" | "/=";
 }
@@ -59,7 +59,8 @@ export interface BinaryOperation {
 
 export interface Symbol {
   type: "Symbol";
-  name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "CX" | "CY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD" | "PICTURE" | "PLAYER_PX" | "PLAYER_PY" | "MOVE_SPEED" | "MOVE_FRAME_TIME" | "LP";
+  // name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "CX" | "CY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD" | "PICTURE" | "PLAYER_PX" | "PLAYER_PY" | "MOVE_SPEED" | "MOVE_FRAME_TIME" | "LP";
+  name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "CX" | "CY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "SOUND_ID" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD" | "PICTURE" | "PLAYER_PX" | "PLAYER_PY" | "MOVE_SPEED" | "MOVE_FRAME_TIME" | "LP";
 }
 
 export interface ArrayOrObject1D {

--- a/packages/engine/src/wwa_expression2/wwa.ts
+++ b/packages/engine/src/wwa_expression2/wwa.ts
@@ -59,7 +59,6 @@ export interface BinaryOperation {
 
 export interface Symbol {
   type: "Symbol";
-  // name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "CX" | "CY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD" | "PICTURE" | "PLAYER_PX" | "PLAYER_PY" | "MOVE_SPEED" | "MOVE_FRAME_TIME" | "LP";
   name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "CX" | "CY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "SOUND_ID" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD" | "PICTURE" | "PLAYER_PX" | "PLAYER_PY" | "MOVE_SPEED" | "MOVE_FRAME_TIME" | "LP";
 }
 

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -1267,26 +1267,14 @@ export class WWA {
         if(moveFunc) {
             this.evalCalcWwaNodeGenerator.evalWwaNode(moveFunc);
         }
-        // const moveaaFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALL_MOVEAA"];
-        // if(moveaaFunc) {
-        //     this.evalCalcWwaNodeGenerator.evalWwaNode(moveaaFunc);
-        // }
     }
 
     /** サウンド再生が終了した際のユーザ定義独自関数を呼び出す */
     public callSoundFinishedDefineFunction(sound: Sound,soundId: number) {
         const soundFinishFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALL_BGM_END"];
 
-        
             this._wwaData.bgm = 0;
-            // console.log("userDefinedFunctions (詳細):", JSON.stringify(this.userDefinedFunctions, null, 2));
-            // console.log("userDefinedFunctions keys:", Object.keys(this.userDefinedFunctions));
-            // Object.entries(this.userDefinedFunctions).forEach(([key, value]) => {
-            //     console.log(`key: ${key}, type: ${typeof value}, value:`, value);
-            // });
         if (soundFinishFunc) {
-                // console.log("いけてるぜ")
-            // this.evalCalcWwaNodeGenerator.evalWwaNode(soundFinishFunc);
             this.evalCalcWwaNodeGenerator.setEarnedSound(soundId);
             
                 console.log(this.evalCalcWwaNodeGenerator.state.earnedSound.soundId);
@@ -1297,8 +1285,6 @@ export class WWA {
             console.log(soundId)
             this.createSoundInstance(soundId)
             this.playSound(soundId);
-            console.log("CALL_BGM_END が登録されていません！");
-            // return false;
         }
     }
 

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -1277,16 +1277,13 @@ export class WWA {
     public callSoundFinishedDefineFunction(sound: Sound,soundId: number) {
         const soundFinishFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALL_BGM_END"];
 
+        //CALL_BGM_END有効時はBGMを自動ループしないため、再生中BGMを初期化する。（＝何もBGMを再生していないものと認識させる。）
         this._wwaData.bgm = 0;
         if (soundFinishFunc) {
             this.evalCalcWwaNodeGenerator.setEarnedSound(soundId);
-            
-                console.log(this.evalCalcWwaNodeGenerator.state.earnedSound.soundId);
             this.evalCalcWwaNodeGenerator.evalWwaNode(soundFinishFunc);
             
-            // return true;
         } else {
-            console.log(soundId)
             this.createSoundInstance(soundId)
             this.playSound(soundId);
         }

--- a/packages/engine/src/wwa_sound.ts
+++ b/packages/engine/src/wwa_sound.ts
@@ -118,7 +118,6 @@ export class Sound {
             duration = 0;
         }
     
-        _wwa.isBgmStopped = false;
         _wwa.soundId = this.id;
         // 再生終了時に呼ばれる処理
         bufferSource.onended = () => {
@@ -128,8 +127,10 @@ export class Sound {
             }
             this.disposeBufferSource(bufferSource);
             if (this.isBgm() && !_wwa.isBgmAllLoop) {
-                //wwa_ts側にBGM再生が終わった旨を連携
-                _wwa.isBgmStopped = true;
+                //BGM再生終わったらキューに処理追加
+                _wwa.enqueueNextFrame(() => {
+                    _wwa.callSoundFinishedDefineFunction(this, this.id);
+                });
             }
         };
         this.delayBgmTimeoutId = window.setTimeout(() => {


### PR DESCRIPTION
カスタムイベント関数『CALL_BGM_END』を実装しました。

- BGMを終わりまで再生したタイミングでイベントを発生させる関数です。
  - このカスタムイベント関数を設定した場合、特定BGMを再生してから別のBGMを立て続けに流したりすることができます。
  - 関数内では変数『SOUND_ID』を使用できます。（値：再生したBGMの番号）
- 一通りの動作確認済み。（CALL_BGM_ENDの有無 + SOUND(xx) / $sound=xx）

設定例
```
function CALL_BGM_END(){
    if(SOUND_ID == 90){ //90:ループ曲用のイントロ部分用BGM→91:ループ部分
        SOUND(91);
    }
    else{ //上記以外は同じBGMを再度呼ぶ
        SOUND(SOUND_ID);
    }
}
```

注意
- CALL_FRAMEと同じタイミングで再生終了したか確認します。
  - WWAのタブがバックグラウンド状態になった場合、BGMの再生終了後にBGMがループしません。
    - ※このカスタムイベント関数を設定していない場合、従来通りのBGMループ挙動となります。
