### PR TITLE
【ピクチャ機能】 ピクチャ内部の Canvas からビットマップ画像に変換する処理を削除

### DIFF
--- a/packages/engine/src/wwa_cgmanager.ts
+++ b/packages/engine/src/wwa_cgmanager.ts
@@ -211,7 +211,7 @@ export class CGManager {
         this.picture.forEachPictures((picture) => {
             const { x, y, width, height } = picture.getDrawPictureCoords();
             // ピクチャは一度に大量の Canvas 画像を描画することになるため、画面全体でサイズ確保して描画すると大きな負荷になる
-            this._ctx.drawImage(picture.imageBitmap, 0, 0, width, height, x, y, width, height);
+            this._ctx.drawImage(picture.canvasImage, 0, 0, width, height, x, y, width, height);
         });
     }
 

--- a/packages/engine/src/wwa_picture/PictureCacheCanvas.ts
+++ b/packages/engine/src/wwa_picture/PictureCacheCanvas.ts
@@ -4,7 +4,6 @@ import { convertAppliableCanvasHeight, convertAppliableCanvasWidth } from "./uti
 export class PictureCacheCanvas {
     private readonly canvas: OffscreenCanvas;
     public ctx: OffscreenCanvasRenderingContext2D;
-    public imageBitmap: ImageBitmap;
 
     constructor(width: number, height: number) {
         this.canvas = new OffscreenCanvas(
@@ -14,18 +13,10 @@ export class PictureCacheCanvas {
         this.ctx = this.canvas.getContext("2d", { alpha: true });
         // TODO オプションでオフにできるようにしたい
         this.ctx.imageSmoothingEnabled = false;
-        this.updateImageBitmap();
     }
 
-    /**
-     * 内部の OffscreenCanvas をより軽量な ImageBitmap に変換生成します。
-     * OffscreenCanvas の内容が変わった場合は必ず実行してください。
-     * サイズがない場合は実行されません。
-     */
-    public updateImageBitmap() {
-        if (this.canvas.width > 0 && this.canvas.height > 0) {
-            this.imageBitmap = this.canvas.transferToImageBitmap();
-        }
+    public getCanvasImage() {
+        return this.canvas;
     }
 
     /**

--- a/packages/engine/src/wwa_picture/WWAPictureItem.ts
+++ b/packages/engine/src/wwa_picture/WWAPictureItem.ts
@@ -198,8 +198,8 @@ export default class WWAPictureItem {
         return this._hasAnimation;
     }
 
-    public get imageBitmap() {
-        return this._canvas.imageBitmap;
+    public get canvasImage() {
+        return this._canvas.getCanvasImage();
     }
 
     public get appearParts() {
@@ -294,7 +294,6 @@ export default class WWAPictureItem {
                 }
             }
         }
-        this._canvas.updateImageBitmap();
     }
 
     public getDrawPictureCoords() {

--- a/packages/engine/src/wwa_picture/utils.ts
+++ b/packages/engine/src/wwa_picture/utils.ts
@@ -263,7 +263,7 @@ export const getVerticalCirclePosition = (y: number, radius: number, angle: numb
 
 /**
  * 指定した横幅を、 Canvas で使用可能な横幅に変換します。
- * 横幅が 0 以下になると OffscreenCanvas では ImageBitmap が正しく出力されないため、1以上の値に調整します。
+ * 横幅が 0 以下になると OffscreenCanvas が機能されないため、1以上の値に調整します。
  * @param width 横幅 (px 単位)
  * @returns Canvas で設定しても安全な状態の横幅 (px 単位)
  */


### PR DESCRIPTION
#799 の対応でピクチャの描画速度を早めるために一度ビットマップに変換する実装をしていました。
ただし一度に大量のピクチャを生成する場合、このビットマップの変換で描画が遅れ、レスポンスが劣化する事象が発生していました。

今回の対応でこのビットマップに変換する過程を削除します。
#799 にあった以下のサンプルコードを Firefox で試したところ、描画は遅れるものの、プレイヤーの操作レスポンスが速くなっていることは確認できています。

```
PICTURE(-1);
for (i = 0; i <= 21; i++) {
  for (j = 0; j <= 21; j++) {
    PICTURE(-1, {
      pos: [i * 20, j * 20],
      time: [10000 + j * 100, j * 100],
      size: [20, 20],
      img: [GET_IMG_POS_X(m[i][j], 1), GET_IMG_POS_Y(m[i][j], 1)],
    });
  }
}
```