### PR TITLE
パーツからピクチャが表示されない不具合を修正

### DIFF
--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -5888,7 +5888,7 @@ export class WWA {
                 triggerPartsX: partsPosition.x,
                 triggerPartsY: partsPosition.y,
                 soundNumber: attributes[WWAConsts.ATR_SOUND] ?? 0,
-                properties,
+                properties: convertMapToObject(properties),
             },
             // TODO この場で generateTokenValues を実行すれば CGManager 側に WWA の参照を作らなくても済む気がする
             partsNumber,


### PR DESCRIPTION
#798 のデグレード対応です。
ピクチャのデータが Object から Map に変わったことで、パーツからプロパティを読み込むピクチャが正しく表示されなくなっていました。

- [x] パーツからプロパティを読み込むピクチャが正しく表示されること
- [x] `next` プロパティが正しく機能すること
- [x] WWA Script からプロパティを読み込むピクチャが正しく表示されること
- [x] ピクチャのある状態でセーブをし、ロードをしても正しくピクチャが復元されること