### PR TITLE
fix(eval): 添字アクセスのエラー表記改善・文字列の添字アクセスを可能に / WWA起動時のスクリプトエラー可視化

### DIFF
--- a/packages/engine/src/load_script_file/index.ts
+++ b/packages/engine/src/load_script_file/index.ts
@@ -1,4 +1,5 @@
 export interface UserScriptResponse {
+  fileName: string;
   kind: string,
   data?: string,
   errorMessage?: string
@@ -9,22 +10,25 @@ export const fetchScriptFile = async (fileName: string): Promise<UserScriptRespo
     const fileResponse = await fetch(fileName);
     if(fileResponse.status === 200 || fileResponse.status === 304) {
       const responseDataString = await new Response(fileResponse.body).text();
-      return <UserScriptResponse> {
+      return  {
         kind: "data",
-        data: responseDataString
+        data: responseDataString,
+        fileName
       }
     }
     else {
-      return <UserScriptResponse> {
+      return  {
         kind: "httpError",
-        errorMessage: `ファイル ${fileName} が読み込めませんでした。ステータスコード: ${fileResponse.status}`
+        errorMessage: `ファイル ${fileName} が読み込めませんでした。ステータスコード: ${fileResponse.status}`,
+        fileName
       }
     }
   }
-  catch(e) {
-    return <UserScriptResponse> {
+  catch(error) {
+    return {
       kind: "otherError",
-      errorMessage: e.message
+      errorMessage: error.message,
+      fileName
     }
   }
 }

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -1160,15 +1160,22 @@ export class WWA {
                 try {
                     this.setUsertScript(loadUserScriptstringsObj);
                 }
-                catch(e) {
-                    console.error(e.message);
+                catch(error) {
+                    alert(`外部スクリプト ${loadUserScriptstringsObj.fileName} の解析中にエラーが発生しました。\nこのままゲームを開始することはできますが、正常に動作しない可能性が高いです。\n\n詳細:\n${error.message}`);
+                    console.error(error.message);
                 }
             })
             
             /** ゲーム開始時のユーザ定義独自関数を呼び出す */
             const gameStartFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALL_WWA_START"];
-            if(gameStartFunc) {
-                this.evalCalcWwaNodeGenerator.evalWwaNode(gameStartFunc);
+            if (gameStartFunc) {
+                try {
+                    this.evalCalcWwaNodeGenerator.evalWwaNode(gameStartFunc);
+                } catch (error) {
+                    // CALL_WWA_START については、通常のメッセージウィンドウがまだ表示されない段階で実行されるため、alertに流す。
+                    alert(`CALL_WWA_START でエラーが発生しました。\n\n詳細:\n${error.message}`)
+                    console.error(error.message);
+                }
             }
         })()
         /** スクリプトパーサーを作成する */

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -6066,6 +6066,9 @@ font-weight: bold;
             } else if (typeof ref === "object" && ref !== null) {
                 const key = String(targetRefIndex);
                 util.setItem(ref, key, result)
+            } else if (typeof ref === "string") {
+                // JavaScript の string はイミュータブルなので書き換え不可
+                throw new TypeError(`文字列 "${ref}" の特定の文字を直接書き換えることはできません`);
             } else {
                 util.setItem(ref, targetRefIndex, result);
             }
@@ -6220,8 +6223,7 @@ font-weight: bold;
     }
     // User名称変数取得
     public getUserNameVar(id: number | string): UserVar {
-        const varValue = this._userVar.named.get(id.toString());
-        return varValue ?? "";
+        return this._userVar.named.get(id.toString());
     }
     // User名称変数の一覧を取得 (ログ出力用)
     public getAllUserNameVar() {

--- a/packages/engine/src/wwa_util.ts
+++ b/packages/engine/src/wwa_util.ts
@@ -107,10 +107,14 @@ export function formatUserVarForDisplay(value: UserVar, trimming?: boolean, dept
   }
 }
 
-export function getItem(x: UserVarMap | Array<any>, key: unknown) {
+export function getItem(x: unknown, key: unknown) {
   if (Array.isArray(x)) {
     if (typeof key !== "number") {
-      throw new TypeError("数字以外をindexにできません");
+      throw new TypeError("配列に対して、数字以外をindexにできません");
+    }
+    if (key < 0 || key >= x.length) {
+      console.warn(`配列のインデックス ${key} は範囲外です`);
+      return undefined;
     }
     return x[key];
   } else if (x instanceof Map) {
@@ -121,12 +125,23 @@ export function getItem(x: UserVarMap | Array<any>, key: unknown) {
       );
     }
     return x.get(String(key));
+  } else if (typeof x === "string") {
+    if (typeof key !== "number") {
+      throw new TypeError(`文字列 "${x}" に対して、数字以外をindexにできません`);
+    }
+    if (key < 0 || key >= x.length) {
+      console.warn(`文字列 "${x}" のインデックス ${key} は範囲外です`);
+      return undefined;
+    }
+    return x[key]; // 文字列中の文字を取得する場合
+  } else if (isPrimitive(x)) {
+    throw new TypeError(`プリミティブ値 ${String(x)} は添字参照できません`);
   } else {
-    throw new TypeError(x satisfies never);
+    throw new TypeError(String(x) + "は添字参照できません");
   }
 }
 export function setItem(
-  x: UserVarMap | Array<any>,
+  x: unknown,
   key: unknown,
   value: UserVar
 ) {
@@ -143,8 +158,12 @@ export function setItem(
       );
     }
     x.set(String(key), value);
+  } else if (typeof x === "string") {
+    throw new TypeError(`文字列 "${x}" の特定の文字を直接書き換えることはできません`);
+  } else if (isPrimitive(x)) {
+    throw new TypeError(`プリミティブ値 ${String(x)} は添字参照できません`);
   } else {
-    throw new TypeError(x satisfies never);
+    throw new TypeError(String(x) + "は添字参照できません");
   }
 }
 


### PR DESCRIPTION

- 存在しないプロパティにアクセスした場合のエラーメッセージを正しくする (現在はメッセージなしのエラーが出る)
- 配列の要素外アクセスをした場合に console.warn を出す
- 外部スクリプトの構文エラーをalert
- CALL_WWA_STARTのランタイムエラーをalert
- 文字列以外もMSGできるようにする
- 文字列の添字アクセスを可能にする (例: "abc"[1]  -> "b")
- 存在しない値にアクセスした場合に空文字列を返しているところをundefinedに変更