### PR TITLE
CALL_BGM_ENDを実装 (調整版)

### DIFF
--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -536,7 +536,7 @@ function convertIdentifer(node: Acorn.Identifier): Wwa.Symbol | Wwa.Literal {
     case "j":
     case "k":
     case "LOOPLIMIT":
-    case "SOUND_ID":
+    case "LAST_BGM_ID":
     case "ITEM_ID":
     case "ITEM_POS":
     case "ENEMY_HP":

--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -536,6 +536,7 @@ function convertIdentifer(node: Acorn.Identifier): Wwa.Symbol | Wwa.Literal {
     case "j":
     case "k":
     case "LOOPLIMIT":
+    case "SOUND_ID":
     case "ITEM_ID":
     case "ITEM_POS":
     case "ENEMY_HP":

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -41,6 +41,11 @@ export class EvalCalcWwaNodeGenerator {
       /** 使用・取得したアイテムの位置 */
       itemPos1To12?: number
     }
+    /** サウンド取得時ならオブジェクトあり, さもなくば undefined. */
+    readonly earnedSound?: {
+      /** 再生サウンドのID */
+      soundId?: number,
+    }
     /** 戦闘ダメージのための計算ならオブジェクトあり, さもなくば undefined */
     readonly battleDamageCalculation?: {
       /** 計算結果に中断が含まれている */
@@ -72,6 +77,13 @@ export class EvalCalcWwaNodeGenerator {
 
   public clearTemporaryState() {
     this.state = { ...this.state, triggerParts: undefined, messagePageAdditionalQueue: [] };
+  }
+  /**
+   * サウンド関連のReadOnly値をセットする
+   * @param sound_id 再生したサウンドのID
+   */
+  public setEarnedSound(soundId: number) {
+    this.state = { ...this.state, earnedSound: { soundId } };
   }
 
   /**
@@ -1249,6 +1261,8 @@ export class EvalCalcWwaNode {
         return this.for_id.k;
       case 'LOOPLIMIT':
         return this.generator.loop_limit;
+      case 'SOUND_ID':
+        return this.generator.state.earnedSound?.soundId ?? -1;
       case 'ITEM_ID':
         return this.generator.state.earnedItem?.partsId ?? -1;
       case 'ITEM_POS':

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -43,9 +43,9 @@ export class EvalCalcWwaNodeGenerator {
       /** 使用・取得したアイテムの位置 */
       itemPos1To12?: number
     }
-    /** サウンド取得時ならオブジェクトあり, さもなくば undefined. */
-    readonly earnedSound?: {
-      /** 再生サウンドのID */
+    /** 過去にBGMが再生れていればオブジェクトあり, さもなくば undefined. */
+    readonly lastBgm?: {
+      /** 最後に再生されたBGMのサウンド番号 */
       soundId?: number,
     }
     /** 戦闘ダメージのための計算ならオブジェクトあり, さもなくば undefined */
@@ -80,12 +80,9 @@ export class EvalCalcWwaNodeGenerator {
   public clearTemporaryState() {
     this.state = { ...this.state, triggerParts: undefined, messagePageAdditionalQueue: [] };
   }
-  /**
-   * サウンド関連のReadOnly値をセットする
-   * @param sound_id 再生したサウンドのID
-   */
-  public setEarnedSound(soundId: number) {
-    this.state = { ...this.state, earnedSound: { soundId } };
+  
+  public setLastBgm(soundId: number) {
+    this.state = { ...this.state, lastBgm: { soundId } };
   }
 
   /**
@@ -1259,8 +1256,8 @@ export class EvalCalcWwaNode {
         return this.for_id.k;
       case 'LOOPLIMIT':
         return this.generator.loop_limit;
-      case 'SOUND_ID':
-        return this.generator.state.earnedSound?.soundId ?? -1;
+      case 'LAST_BGM_ID':
+        return this.generator.state.lastBgm?.soundId ?? -1;
       case 'ITEM_ID':
         return this.generator.state.earnedItem?.partsId ?? -1;
       case 'ITEM_POS':

--- a/packages/engine/src/wwa_expression2/wwa.ts
+++ b/packages/engine/src/wwa_expression2/wwa.ts
@@ -39,7 +39,7 @@ export interface LoopPointerAssignment {
 
 export interface SpecialParameterAssignment {
   type: "SpecialParameterAssignment";
-  kind: "PX" | "PY" | "HP" | "HPMAX" | "AT" | "DF" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS";
+  kind: "PX" | "PY" | "HP" | "HPMAX" | "AT" | "DF" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "SOUND_ID" ;
   value: Calcurable;
   operator?: "=" | "+=" | "-=" | "*=" | "/=";
 }
@@ -59,7 +59,8 @@ export interface BinaryOperation {
 
 export interface Symbol {
   type: "Symbol";
-  name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "CX" | "CY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD" | "PICTURE" | "PLAYER_PX" | "PLAYER_PY" | "MOVE_SPEED" | "MOVE_FRAME_TIME" | "LP";
+  // name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "CX" | "CY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD" | "PICTURE" | "PLAYER_PX" | "PLAYER_PY" | "MOVE_SPEED" | "MOVE_FRAME_TIME" | "LP";
+  name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "CX" | "CY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "SOUND_ID" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD" | "PICTURE" | "PLAYER_PX" | "PLAYER_PY" | "MOVE_SPEED" | "MOVE_FRAME_TIME" | "LP";
 }
 
 export interface ArrayOrObject1D {

--- a/packages/engine/src/wwa_expression2/wwa.ts
+++ b/packages/engine/src/wwa_expression2/wwa.ts
@@ -59,7 +59,6 @@ export interface BinaryOperation {
 
 export interface Symbol {
   type: "Symbol";
-  // name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "CX" | "CY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD" | "PICTURE" | "PLAYER_PX" | "PLAYER_PY" | "MOVE_SPEED" | "MOVE_FRAME_TIME" | "LP";
   name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "CX" | "CY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "SOUND_ID" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD" | "PICTURE" | "PLAYER_PX" | "PLAYER_PY" | "MOVE_SPEED" | "MOVE_FRAME_TIME" | "LP";
 }
 

--- a/packages/engine/src/wwa_expression2/wwa.ts
+++ b/packages/engine/src/wwa_expression2/wwa.ts
@@ -39,7 +39,7 @@ export interface LoopPointerAssignment {
 
 export interface SpecialParameterAssignment {
   type: "SpecialParameterAssignment";
-  kind: "PX" | "PY" | "HP" | "HPMAX" | "AT" | "DF" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "SOUND_ID" ;
+  kind: "PX" | "PY" | "HP" | "HPMAX" | "AT" | "DF" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "LAST_BGM_ID" ;
   value: Calcurable;
   operator?: "=" | "+=" | "-=" | "*=" | "/=";
 }
@@ -59,7 +59,7 @@ export interface BinaryOperation {
 
 export interface Symbol {
   type: "Symbol";
-  name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "CX" | "CY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "SOUND_ID" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD" | "PICTURE" | "PLAYER_PX" | "PLAYER_PY" | "MOVE_SPEED" | "MOVE_FRAME_TIME" | "LP";
+  name: "ITEM" | "m" | "o" | "v" | "X" | "Y" | "ID" | "TYPE" | "PX" | "PY" | "CX" | "CY" | "HP" | "HPMAX" | "AT" | "AT_TOTAL" | "DF" | "DF_TOTAL" | "GD" | "STEP" | "TIME" | "PDIR" | "i" | "j" | "k" | "LOOPLIMIT" | "ITEM_ID" | "ITEM_POS" | "LAST_BGM_ID" | "ENEMY_HP" | "ENEMY_AT" | "ENEMY_DF" | "ENEMY_GD" | "PICTURE" | "PLAYER_PX" | "PLAYER_PY" | "MOVE_SPEED" | "MOVE_FRAME_TIME" | "LP";
 }
 
 export interface ArrayOrObject1D {

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -1267,26 +1267,14 @@ export class WWA {
         if(moveFunc) {
             this.evalCalcWwaNodeGenerator.evalWwaNode(moveFunc);
         }
-        // const moveaaFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALL_MOVEAA"];
-        // if(moveaaFunc) {
-        //     this.evalCalcWwaNodeGenerator.evalWwaNode(moveaaFunc);
-        // }
     }
 
     /** サウンド再生が終了した際のユーザ定義独自関数を呼び出す */
     public callSoundFinishedDefineFunction(sound: Sound,soundId: number) {
         const soundFinishFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALL_BGM_END"];
 
-        
             this._wwaData.bgm = 0;
-            // console.log("userDefinedFunctions (詳細):", JSON.stringify(this.userDefinedFunctions, null, 2));
-            // console.log("userDefinedFunctions keys:", Object.keys(this.userDefinedFunctions));
-            // Object.entries(this.userDefinedFunctions).forEach(([key, value]) => {
-            //     console.log(`key: ${key}, type: ${typeof value}, value:`, value);
-            // });
         if (soundFinishFunc) {
-                // console.log("いけてるぜ")
-            // this.evalCalcWwaNodeGenerator.evalWwaNode(soundFinishFunc);
             this.evalCalcWwaNodeGenerator.setEarnedSound(soundId);
             
                 console.log(this.evalCalcWwaNodeGenerator.state.earnedSound.soundId);
@@ -1297,8 +1285,6 @@ export class WWA {
             console.log(soundId)
             this.createSoundInstance(soundId)
             this.playSound(soundId);
-            console.log("CALL_BGM_END が登録されていません！");
-            // return false;
         }
     }
 

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -1277,16 +1277,13 @@ export class WWA {
     public callSoundFinishedDefineFunction(sound: Sound,soundId: number) {
         const soundFinishFunc = this.userDefinedFunctions && this.userDefinedFunctions["CALL_BGM_END"];
 
+        //CALL_BGM_END有効時はBGMを自動ループしないため、再生中BGMを初期化する。（＝何もBGMを再生していないものと認識させる。）
         this._wwaData.bgm = 0;
         if (soundFinishFunc) {
             this.evalCalcWwaNodeGenerator.setEarnedSound(soundId);
-            
-                console.log(this.evalCalcWwaNodeGenerator.state.earnedSound.soundId);
             this.evalCalcWwaNodeGenerator.evalWwaNode(soundFinishFunc);
             
-            // return true;
         } else {
-            console.log(soundId)
             this.createSoundInstance(soundId)
             this.playSound(soundId);
         }

--- a/packages/engine/src/wwa_sound.ts
+++ b/packages/engine/src/wwa_sound.ts
@@ -118,7 +118,6 @@ export class Sound {
             duration = 0;
         }
     
-        _wwa.isBgmStopped = false;
         _wwa.soundId = this.id;
         // 再生終了時に呼ばれる処理
         bufferSource.onended = () => {
@@ -128,8 +127,10 @@ export class Sound {
             }
             this.disposeBufferSource(bufferSource);
             if (this.isBgm() && !_wwa.isBgmAllLoop) {
-                //wwa_ts側にBGM再生が終わった旨を連携
-                _wwa.isBgmStopped = true;
+                //BGM再生終わったらキューに処理追加
+                _wwa.enqueueNextFrame(() => {
+                    _wwa.callSoundFinishedDefineFunction(this, this.id);
+                });
             }
         };
         this.delayBgmTimeoutId = window.setTimeout(() => {

--- a/packages/engine/src/wwa_sound.ts
+++ b/packages/engine/src/wwa_sound.ts
@@ -95,21 +95,15 @@ export class Sound {
     /**
      * 音声を再生します。
      * 一時停止した場合でも、最初から再生します。
-     * @param delayDurationMs 遅延時間
+     * @param delayDurationMs 遅延時間 [ms]
+     * @param bgmLoopDisabled 再生するサウンドがBGMの場合、ループを無効にするかどうか。効果音の場合は無視されます。
+     * @param playingEndCallback 再生終了時に呼ばれるコールバック関数
      */
-    public play(_wwa: WWA, delayDurationMs = 0): void {
-        const bufferSource: AudioBufferSourceNode = this.audioContext.createBufferSource();
+    public play(delayDurationMs = 0, bgmLoopDisabled: boolean = false, playingEndCallback?: () => void): void {
+        const bufferSource = this.audioContext.createBufferSource();
         this.bufferSources.push(bufferSource);
-    
         bufferSource.buffer = this.audioBuffer;
-        //ユーザ定義独自関数『CALL_BGM_END』が設定されていない＆BGMであればtrue、それ以外はfalse
-        if(_wwa.isBgmAllLoop && this.isBgm()){
-            bufferSource.loop = true;
-        }
-        else{
-            bufferSource.loop = false;
-        }
-
+        bufferSource.loop = Boolean(!bgmLoopDisabled && this.isBgm());
         bufferSource.connect(this.audioGain);
 
         // TODO(rmn): bufferSource.buffer.duration ? あとで調べる
@@ -118,21 +112,18 @@ export class Sound {
             duration = 0;
         }
     
-        _wwa.soundId = this.id;
-        // 再生終了時に呼ばれる処理
-        bufferSource.onended = () => {
-            const id = this.bufferSources.indexOf(bufferSource);
-            if (id !== -1) {
-                this.bufferSources.splice(id, 1);
+        const onBufferPlayEnded = () => {
+            bufferSource.removeEventListener("ended", onBufferPlayEnded);
+            const bufferSourceIndex = this.bufferSources.indexOf(bufferSource);
+            if (bufferSourceIndex !== -1) {
+                this.bufferSources.splice(bufferSourceIndex, 1);
             }
             this.disposeBufferSource(bufferSource);
-            if (this.isBgm() && !_wwa.isBgmAllLoop) {
-                //BGM再生終わったらキューに処理追加
-                _wwa.enqueueNextFrame(() => {
-                    _wwa.callSoundFinishedDefineFunction(this, this.id);
-                });
-            }
-        };
+            playingEndCallback?.();
+        }
+
+        // 再生終了時に呼ばれる処理
+        bufferSource.addEventListener("ended", onBufferPlayEnded);
         this.delayBgmTimeoutId = window.setTimeout(() => {
             this.delayBgmTimeoutId = null;
             bufferSource.start();


### PR DESCRIPTION
@zokugami さんの #800 を調整するPR

- `SOUND_ID` は `LAST_BGM_ID` にリネームしました
- `CALL_BGM_END` の定義の有無に関わらず、 `LAST_BGM_ID` は更新されます

```
function CALL_BGM_END(){
    if(SOUND_ID == 90){ //90:ループ曲用のイントロ部分用BGM→91:ループ部分
        SOUND(91);
    }
    else{ //上記以外は同じBGMを再度呼ぶ
        SOUND(LAST_BGM_ID);
    }
}
```