### PR TITLE
feat(expression2): 三角関数やべき乗関連の関数を追加

### DIFF
--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -211,6 +211,11 @@ function convertCallExpression(node: Acorn.CallExpression): Wwa.WWANode  {
     case "HAS_PICTURE":
     case "SHOW_USER_DEF_VAR":
     case "ABS":
+    case "POW":
+    case "SQRT":
+    case "SIN":
+    case "COS":
+    case "TAN":
     case "GET_GAMEOVER_POS_X":
     case "GET_GAMEOVER_POS_Y":
     case "ABORT_BATTLE":

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -787,6 +787,32 @@ export class EvalCalcWwaNode {
         const value = Number(this.evalWwaNode(node.value[0]));
         return Math.abs(value);
       }
+      case "POW": {
+        this._checkArgsLength(2, node);
+        const base = Number(this.evalWwaNode(node.value[0]));
+        const exponent = Number(this.evalWwaNode(node.value[1]));
+        return Math.pow(base, exponent);
+      }
+      case "SQRT": {
+        this._checkArgsLength(1, node);
+        const value = Number(this.evalWwaNode(node.value[0]));
+        return Math.sqrt(value);
+      }
+      case "SIN": {
+        this._checkArgsLength(1, node);
+        const value = Number(this.evalWwaNode(node.value[0]));
+        return Math.sin(value);
+      }
+      case "COS": {
+        this._checkArgsLength(1, node);
+        const value = Number(this.evalWwaNode(node.value[0]));
+        return Math.cos(value);
+      }
+      case "TAN": {
+        this._checkArgsLength(1, node);
+        const value = Number(this.evalWwaNode(node.value[0]));
+        return Math.tan(value);
+      }
       /** ゲームオーバー座標取得関数たち */
       case "GET_GAMEOVER_POS_X": {
         const pos = this.generator.wwa.getGemeOverPosition();

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -5,7 +5,7 @@ import { WWA } from "../wwa_main";
 import { getItem } from "../wwa_util";
 import * as Wwa from "./wwa";
 import { Literal } from "./wwa";
-import { PARTS_TYPE_LIST } from "./utils";
+import { isLowerThanEpsilon, PARTS_TYPE_LIST } from "./utils";
 import { evalLengthFunction } from "./functions/length";
 import { getPlayerCoordPx, getPlayerCoordPy } from "./symbols";
 import { PageAdditionalItem } from "./typedef";
@@ -800,18 +800,30 @@ export class EvalCalcWwaNode {
       }
       case "SIN": {
         this._checkArgsLength(1, node);
-        const value = Number(this.evalWwaNode(node.value[0]));
-        return Math.sin(value);
+        const angle = Number(this.evalWwaNode(node.value[0]));
+        const value = Math.sin(angle * Math.PI / 180.0);
+        if (isLowerThanEpsilon(value)) {
+          return 0;
+        }
+        return value;
       }
       case "COS": {
         this._checkArgsLength(1, node);
-        const value = Number(this.evalWwaNode(node.value[0]));
-        return Math.cos(value);
+        const angle = Number(this.evalWwaNode(node.value[0]));
+        const value = Math.cos(angle * Math.PI / 180.0);
+        if (isLowerThanEpsilon(value)) {
+          return 0;
+        }
+        return value;
       }
       case "TAN": {
         this._checkArgsLength(1, node);
-        const value = Number(this.evalWwaNode(node.value[0]));
-        return Math.tan(value);
+        const angle = Number(this.evalWwaNode(node.value[0]));
+        const value = Math.tan(angle * Math.PI / 180.0);
+        if (isLowerThanEpsilon(value)) {
+          return 0;
+        }
+        return value;
       }
       /** ゲームオーバー座標取得関数たち */
       case "GET_GAMEOVER_POS_X": {

--- a/packages/engine/src/wwa_expression2/utils.ts
+++ b/packages/engine/src/wwa_expression2/utils.ts
@@ -8,4 +8,4 @@ export const PARTS_TYPE_LIST = [PartsType.OBJECT, PartsType.MAP];
  * その誤差が原因で、限りなく 0 に近いものの、扱いにくい値 (1.2246467991473532e-16) が算出されます。
  * この場合、 true として判定されることを想定しています。
  */
-export const isLowerThanEpsilon = (value: number) => Math.abs(value) < 1e-10;
+export const isLowerThanEpsilon = (value: number) => Math.abs(value) < Number.EPSILON;

--- a/packages/engine/src/wwa_expression2/utils.ts
+++ b/packages/engine/src/wwa_expression2/utils.ts
@@ -1,3 +1,11 @@
 import { PartsType } from "../wwa_data";
 
 export const PARTS_TYPE_LIST = [PartsType.OBJECT, PartsType.MAP];
+
+/**
+ * 0 に限りなく近く、 0 に丸めるべきか判定する関数です。
+ * SIN, COS, TAN の三角関数で180度を指定した場合、円周率同士の算出で誤差が生じます。
+ * その誤差が原因で、限りなく 0 に近いものの、扱いにくい値 (1.2246467991473532e-16) が算出されます。
+ * この場合、 true として判定されることを想定しています。
+ */
+export const isLowerThanEpsilon = (value: number) => Math.abs(value) < 1e-10;


### PR DESCRIPTION
Issue Close: #819 

WWA Script で以下の関数を追加します。

- 三角関数
    - `SIN`
    - `COS`
    - `TAN`
- 数学関数
    - `POW`
    - `SQRT`

JavaScript API の三角関数では引数がラジアン値になっています。このままでは扱いづらいため、角度でも変換できるようにしています。
ただし180度を指定した場合、π の値の誤差で `1.2246467991473532e-16` のような0に近いけど0じゃない値が発生するため、この場合は丸め処理で 0 に寄せます。

<img width="882" height="600" alt="Screenshot 2026-01-02 at 00-15-18 World Wide Adventure Wing" src="https://github.com/user-attachments/assets/470fb058-c5a7-44ca-893e-beca6a753a33" />

## サンプル: 恐怖のシルクハッ島の無限シルクハットを疑似再現

```js
PICTURE(-1);
for (i = 0; i < 360; i++) {
  PICTURE(-1, {
    pos: [200, 200],
    time: [(i * 20) + 10000, i * 20],
    img: [4, 6],
    move: [COS(i * 10) * 2, SIN(i * 10) * 2],
    angle: -270 + i * 10,
  });
}
```

開発モードで稼働の上、デバッグコンソールに上記コードを実行してみよう！