### PR TITLE
fix(manual-pause): 他ポーズ時の割り込み禁止化・空メッセージでポーズしない不具合を修正

### DIFF
--- a/packages/engine/src/wwa_data.ts
+++ b/packages/engine/src/wwa_data.ts
@@ -1090,3 +1090,16 @@ export interface BattleEstimateParameters {
  * 戦闘ダメージ方向の定義
  */
 export type BattleDamageDirection = "playerToEnemy" | "enemyToPlayer";
+
+/**
+ * マニュアルポーズ情報
+ */
+export interface ManualPauseInformation {
+    functionNames: {
+        cancelPause: string;
+        up: string;
+        down: string;
+        right: string;
+        left: string;
+    }
+}

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -895,20 +895,15 @@ export class EvalCalcWwaNode {
       }
       case "MANUAL_PAUSE":
       case "WAIT_ENTER": {
-        // valueで評価した関数名を読み込む
-        const value = node.value[0]? this.evalWwaNode(node.value[0]): "";
-        const noMessageWaitingExecFuncNames: {
-          up: string,
-          down: string,
-          right: string,
-          left: string
-        } = {
-          up: node.value[1] ? this.evalWwaNode(node.value[1]) : "",
-          down: node.value[2] ? this.evalWwaNode(node.value[2]) : "",
-          right: node.value[3] ? this.evalWwaNode(node.value[3]) : "",
-          left: node.value[4] ? this.evalWwaNode(node.value[4]) : "",
-        }
-        this.generator.wwa.manualPause(value, noMessageWaitingExecFuncNames);
+        this.generator.wwa.manualPause({
+          functionNames: {
+            cancelPause: node.value[0]? this.evalWwaNode(node.value[0]): "",
+            up: node.value[1] ? this.evalWwaNode(node.value[1]) : "",
+            down: node.value[2] ? this.evalWwaNode(node.value[2]) : "",
+            right: node.value[3] ? this.evalWwaNode(node.value[3]) : "",
+            left: node.value[4] ? this.evalWwaNode(node.value[4]) : ""
+          }
+        });
         return;
       }
       case "COLOR": {

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -11,7 +11,7 @@ import {
     speedNameList, MoveType, AppearanceTriggerType, vx, vy, EquipmentStatus, SecondCandidateMoveType,
     ChangeStyleType, MacroStatusIndex, SelectorType, IDTable, UserDevice, OS_TYPE, DEVICE_TYPE, BROWSER_TYPE, ControlPanelBottomButton, MacroImgFrameIndex, DrawPartsData,
     StatusKind, StatusSolutionKind, UserVarNameListRequestErrorKind, ScoreOption, TriggerParts, WWAConsts, type UserVariableKind, type BattleTurnResult, BattleEstimateParameters, BattleDamageDirection,
-    type UserVar, type UserVarMap, type UserVarPrimitive
+    type UserVar, type UserVarMap, type UserVarPrimitive, type ManualPauseInformation
 } from "./wwa_data";
 
 import {
@@ -59,7 +59,6 @@ import * as ExpressionParser2 from "./wwa_expression2";
 import { UserScriptResponse, fetchScriptFile } from "./load_script_file";
 import { WWANode } from "./wwa_expression2/wwa";
 import * as VarDump from "./wwa_vardump"
-import { DataWWAOptions } from "./wwa_data/typedef";
 import { makeDefaultWWAOptions } from "./wwa_data/options";
 import { PageAdditionalItem } from "./wwa_expression2/typedef";
 
@@ -2800,6 +2799,7 @@ export class WWA {
             }
             this._objectMovingDataManager.update();
         } else if (this._player.isManualPause()) {
+            const manualPauseInformation = this._player.getManualPauseInformation();
             if (
                 this._keyStore.getKeyState(KeyCode.KEY_ENTER) === KeyState.KEYDOWN ||
                 this._keyStore.getKeyStateForMessageCheck(KeyCode.KEY_SPACE) === KeyState.KEYDOWN ||
@@ -2809,9 +2809,9 @@ export class WWA {
                 this._virtualPadStore.checkTouchButton("BUTTON_ENTER") ||
                 this._virtualPadStore.checkTouchButton("BUTTON_ESC")
             ) {
+                const functionName = manualPauseInformation?.functionNames.cancelPause ?? "";
                 // マニュアルポーズを解除 
                 this._player.clearWaitingMessageOrManualPause();
-                const functionName = this._player.getAfterEnterExecFuncName();
                 if (functionName !== "") {
                     try {
                         this.evalCalcWwaNodeGenerator.evalWwaNode({ type: "CallDefinedFunction", functionName });
@@ -2822,14 +2822,13 @@ export class WWA {
                 } 
             }
 
-            const noMessageWaitExecFuncNames = this._player.getNoMessageWaitExecFuncNames();
             ([
                 { keyCode: KeyCode.KEY_UP, funcKey: "up" },
                 { keyCode: KeyCode.KEY_DOWN, funcKey: "down" },
                 { keyCode: KeyCode.KEY_RIGHT, funcKey: "right" },
                 { keyCode: KeyCode.KEY_LEFT, funcKey: "left" }
-            ] satisfies { keyCode: number, funcKey: keyof typeof noMessageWaitExecFuncNames }[]).forEach(({keyCode, funcKey}) => {
-                const functionName = noMessageWaitExecFuncNames[funcKey];
+            ] satisfies { keyCode: number, funcKey: Exclude<keyof typeof manualPauseInformation["functionNames"], "cancelPause"> }[]).forEach(({keyCode, funcKey}) => {
+                const functionName = manualPauseInformation?.functionNames[funcKey] ?? "";
                 if (this._keyStore.getKeyState(keyCode) === KeyState.KEYDOWN && functionName !== "") {               
                     try {
                         this.evalCalcWwaNodeGenerator.evalWwaNode({ type: "CallDefinedFunction", functionName });
@@ -5638,7 +5637,11 @@ export class WWA {
                 this._keyStore.allClear();
                 this._mouseStore.clear();
             }
-            this._player.clearWaitingMessageOrManualPause();
+            // メッセージが発生しないパーツでマニュアルポーズが発生する場合は。プレイヤーを制御可能にせず、マニュアルポーズ状態を維持する。
+            // メッセージが発生するパーツにおいてはマニュアルポーズはできない。
+            if (!this._player.isManualPause()) {
+                this._player.clearWaitingMessageOrManualPause();
+            }
             return { newPageGenerated: false };
         } else {
             this.registerPageByMessage(
@@ -7177,19 +7180,8 @@ font-weight: bold;
         this._wwaData.customSystemMessages[key] = message;
     }
 
-    public manualPause(
-        afterEnterExecFuncName: string,
-        noMessageWaitingExecFuncNames: {
-            up: string,
-            down: string,
-            right: string,
-            left: string
-        }
-    ) {
-        this._player.setManualPause(
-            afterEnterExecFuncName,
-            noMessageWaitingExecFuncNames
-        );
+    public manualPause(manualPauseInformation: ManualPauseInformation): void {
+        this._player.setManualPause(manualPauseInformation);
     }
 };
 

--- a/packages/engine/src/wwa_parts_player.ts
+++ b/packages/engine/src/wwa_parts_player.ts
@@ -9,10 +9,10 @@ import {
     speedList,
     PartsType,
     ItemMode,
-    SystemSound,
     AppearanceTriggerType,
     Coord,
     type BattleTurnResult,
+    ManualPauseInformation,
 } from "./wwa_data";
 import { Camera } from "./wwa_camera";
 import { Monster } from "./wwa_monster";
@@ -114,16 +114,7 @@ export class Player extends PartsObject {
     // 戦闘していない場合は 0。
     protected _battleNoDamageTurnLength: number;
 
-    // メッセージ非表示待機後に呼ばれるユーザー定義関数
-    protected _afterEnterExecFuncName: string;
-
-    /** メッセージ非表示待機中に上下左右キーが押されたときに呼ばれるユーザー定義関数 */
-    protected _noMessageWaitingExecFuncNames: {
-        up: string,
-        down: string,
-        right: string,
-        left: string
-    }
+    protected _manualPauseInformation: ManualPauseInformation | undefined;
 
     public move(): void {
         if (this.isControllable()) {
@@ -351,23 +342,15 @@ export class Player extends PartsObject {
         this._state = PlayerState.MESSAGE_WAITING;
     }
 
-    // メッセージ非表示でEnterクリック待機状態とする
-
-    public setManualPause(
-        afterEnterExecFuncName: string,
-        noMessageWaitingExecFuncNames: {
-            up: string,
-            down: string,
-            right: string,
-            left: string
-        }
-    ): void {
+    public setManualPause(manualPauseInformation: ManualPauseInformation): void {
         if (!this.isControllable()) {
+            if (this._state === PlayerState.MESSAGE_WAITING) {
+                console.warn("メッセージが表示されるパーツではマニュアルポーズはできません。");
+            }
             return;
         }
         this._state = PlayerState.MANUAL_PAUSE;
-        this._afterEnterExecFuncName = afterEnterExecFuncName;
-        this._noMessageWaitingExecFuncNames = noMessageWaitingExecFuncNames
+        this._manualPauseInformation = manualPauseInformation;
     }
 
     public isWaitingMessageOrManualPause(): boolean {
@@ -385,17 +368,8 @@ export class Player extends PartsObject {
         return this._state === PlayerState.MANUAL_PAUSE;
     }
 
-    public getAfterEnterExecFuncName(): string {
-        return this._afterEnterExecFuncName;
-    }
-
-    public getNoMessageWaitExecFuncNames(): {
-        up: string,
-        down: string,
-        right: string,
-        left: string
-    } {
-        return this._noMessageWaitingExecFuncNames;
+    public getManualPauseInformation(): ManualPauseInformation | undefined {
+        return this._manualPauseInformation;
     }
 
     public isDelayFrame(): boolean {
@@ -410,6 +384,9 @@ export class Player extends PartsObject {
     }
 
     public clearWaitingMessageOrManualPause(): void {
+        if (this._state === PlayerState.MANUAL_PAUSE) {
+            this._manualPauseInformation = undefined;
+        }
         const isWaiting = this.isWaitingMessageOrManualPause();
         if (!isWaiting && this._state !== PlayerState.LOCALGATE_JUMPED_WITH_MESSAGE) {
             return;


### PR DESCRIPTION
- [x] WWA Script 入力欄からマニュアルポーズできる
- [x] メッセージが発生しないパーツでマニュアルポーズできる
- [x] メッセージが発生するパーツではマニュアルポーズできない
- [x] `<p>` や` MSG("")` が絡むケースも確認する