### PR TITLE
feat(manual-pause): スクリプト以外から解除できないマニュアルポーズ追加, 解除関数追加

### DIFF
--- a/packages/engine/src/wwa_data.ts
+++ b/packages/engine/src/wwa_data.ts
@@ -1102,4 +1102,5 @@ export interface ManualPauseInformation {
         right: string;
         left: string;
     }
+    blockingCancelPauseByPlayer: boolean;
 }

--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -236,6 +236,8 @@ function convertCallExpression(node: Acorn.CallExpression): Wwa.WWANode  {
     case "IS_NUMBER":
     case "MANUAL_PAUSE":
     case "WAIT_ENTER":
+    case "CANCEL_MANUAL_PAUSE":
+    case "CANCEL_WAIT_ENTER":
     case "COLOR":
     case "EFFITEM":
     case "CHANGE_BOM_IMG":

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -961,15 +961,23 @@ export class EvalCalcWwaNode {
       }
       case "MANUAL_PAUSE":
       case "WAIT_ENTER": {
+        const arg0 = this.evalWwaNode(node.value[0]);
+        const blockingCancelPauseByPlayer = arg0 === "__BLOCK";
         this.generator.wwa.manualPause({
           functionNames: {
-            cancelPause: node.value[0]? this.evalWwaNode(node.value[0]): "",
+            cancelPause: arg0 && !blockingCancelPauseByPlayer ? arg0 : "",
             up: node.value[1] ? this.evalWwaNode(node.value[1]) : "",
             down: node.value[2] ? this.evalWwaNode(node.value[2]) : "",
             right: node.value[3] ? this.evalWwaNode(node.value[3]) : "",
             left: node.value[4] ? this.evalWwaNode(node.value[4]) : ""
-          }
+          },
+          blockingCancelPauseByPlayer 
         });
+        return;
+      }
+      case "CANCEL_MANUAL_PAUSE":
+      case "CANCEL_WAIT_ENTER": {
+        this.generator.wwa.cancelManualPause();
         return;
       }
       case "COLOR": {

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -2806,13 +2806,15 @@ export class WWA {
         } else if (this._player.isManualPause()) {
             const manualPauseInformation = this._player.getManualPauseInformation();
             if (
-                this._keyStore.getKeyState(KeyCode.KEY_ENTER) === KeyState.KEYDOWN ||
-                this._keyStore.getKeyStateForMessageCheck(KeyCode.KEY_SPACE) === KeyState.KEYDOWN ||
-                this._keyStore.getKeyStateForMessageCheck(KeyCode.KEY_ESC) === KeyState.KEYDOWN ||
-                this._mouseStore.getMouseState() === MouseState.MOUSEDOWN ||
-                this._gamePadStore.buttonTrigger(GamePadState.BUTTON_INDEX_A, GamePadState.BUTTON_INDEX_B) ||
-                this._virtualPadStore.checkTouchButton("BUTTON_ENTER") ||
-                this._virtualPadStore.checkTouchButton("BUTTON_ESC")
+                !manualPauseInformation.blockingCancelPauseByPlayer && (
+                    this._keyStore.getKeyState(KeyCode.KEY_ENTER) === KeyState.KEYDOWN ||
+                    this._keyStore.getKeyStateForMessageCheck(KeyCode.KEY_SPACE) === KeyState.KEYDOWN ||
+                    this._keyStore.getKeyStateForMessageCheck(KeyCode.KEY_ESC) === KeyState.KEYDOWN ||
+                    this._mouseStore.getMouseState() === MouseState.MOUSEDOWN ||
+                    this._gamePadStore.buttonTrigger(GamePadState.BUTTON_INDEX_A, GamePadState.BUTTON_INDEX_B) ||
+                    this._virtualPadStore.checkTouchButton("BUTTON_ENTER") ||
+                    this._virtualPadStore.checkTouchButton("BUTTON_ESC")
+                )
             ) {
                 const functionName = manualPauseInformation?.functionNames.cancelPause ?? "";
                 // マニュアルポーズを解除 
@@ -7186,8 +7188,12 @@ font-weight: bold;
         this._wwaData.customSystemMessages[key] = message;
     }
 
-    public manualPause(manualPauseInformation: ManualPauseInformation): void {
-        this._player.setManualPause(manualPauseInformation);
+    public manualPause(manualPauseInformation: ManualPauseInformation, blockingCancelPauseByPlayer: boolean = false): void {
+        this._player.setManualPause(manualPauseInformation, blockingCancelPauseByPlayer);
+    }
+
+    public cancelManualPause(): void {
+        this._player.clearWaitingMessageOrManualPause();
     }
 };
 

--- a/packages/engine/src/wwa_parts_player.ts
+++ b/packages/engine/src/wwa_parts_player.ts
@@ -349,7 +349,7 @@ export class Player extends PartsObject {
         this._state = PlayerState.MESSAGE_WAITING;
     }
 
-    public setManualPause(manualPauseInformation: ManualPauseInformation): void {
+    public setManualPause(manualPauseInformation: ManualPauseInformation, blockingCancelPauseByPlayer: boolean = false): void {
         if (!this.isControllable()) {
             return;
         }


### PR DESCRIPTION
- `MANUAL_PAUSE("__BLOCK")` と記述することで、ENTERなどの決定でのポーズ解除を無効化できます
- `CANCEL_MANUAL_PAUSE()` でマニュアルポーズをスクリプトから解除できるようになります。