### PR TITLE
【WWAScript】小数点付き割り算と切り捨て、切り上げ、四捨五入関数を追加

### DIFF
--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -224,6 +224,10 @@ function convertCallExpression(node: Acorn.CallExpression): Wwa.WWANode  {
     case "CLEAR_ALL_PICTURES":
     case "HAS_PICTURE":
     case "SHOW_USER_DEF_VAR":
+    case "DIV":
+    case "FLOOR":
+    case "CEIL":
+    case "ROUND":
     case "ABS":
     case "POW":
     case "SQRT":

--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -242,6 +242,7 @@ function convertCallExpression(node: Acorn.CallExpression): Wwa.WWANode  {
     case "GET_IMG_POS_Y":
     case "LENGTH":
     case "IS_NUMBER":
+    case "IS_NAN":
     case "CLONE":
     case "MANUAL_PAUSE":
     case "WAIT_ENTER":

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -871,10 +871,8 @@ export class EvalCalcWwaNode {
         this._checkArgsLength(2, node);
         const dividend = Number(this.evalWwaNode(node.value[0]));
         const divisor = Number(this.evalWwaNode(node.value[1]));
-        if (divisor === 0) {
-          return NaN;
-        }
         // "DIV" 関数は小数点以下の値も含める
+        // 0 除算は Infinity を返すが、仕様通りの挙動
         return dividend / divisor;
       }
       case "FLOOR": {

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -867,6 +867,31 @@ export class EvalCalcWwaNode {
         const hasPicture = game_status.wwaData.pictureRegistry.some((item) => item.layerNumber === layerNumber);
         return hasPicture;
       }
+      case "DIV": {
+        this._checkArgsLength(2, node);
+        const dividend = Number(this.evalWwaNode(node.value[0]));
+        const divisor = Number(this.evalWwaNode(node.value[1]));
+        if (divisor === 0) {
+          return 0;
+        }
+        // "DIV" 関数は小数点以下の値も含める
+        return dividend / divisor;
+      }
+      case "FLOOR": {
+        this._checkArgsLength(1, node);
+        const value = Number(this.evalWwaNode(node.value[0]));
+        return Math.floor(value);
+      }
+      case "CEIL": {
+        this._checkArgsLength(1, node);
+        const value = Number(this.evalWwaNode(node.value[0]));
+        return Math.ceil(value);
+      }
+      case "ROUND": {
+        this._checkArgsLength(1, node);
+        const value = Number(this.evalWwaNode(node.value[0]));
+        return Math.round(value);
+      }
       /** 絶対値を返す関数 */
       case "ABS": {
         this._checkArgsLength(1, node);

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -872,7 +872,7 @@ export class EvalCalcWwaNode {
         const dividend = Number(this.evalWwaNode(node.value[0]));
         const divisor = Number(this.evalWwaNode(node.value[1]));
         if (divisor === 0) {
-          return 0;
+          return NaN;
         }
         // "DIV" 関数は小数点以下の値も含める
         return dividend / divisor;
@@ -1011,6 +1011,11 @@ export class EvalCalcWwaNode {
         this._checkArgsLength(1, node);
         const value = this.evalWwaNode(node.value[0]);
         return typeof value === "number";
+      }
+      case "IS_NAN": {
+        this._checkArgsLength(1, node);
+        const value = this.evalWwaNode(node.value[0]);
+        return isNaN(value);
       }
       case "CLONE": {
         this._checkArgsLength(1, node);


### PR DESCRIPTION
以下の関数を追加します。

## `DIV` 関数
やることは割り算ですが、小数点以下が発生した場合はそのまま残ります。

- `1/3` → 従来は `0` だが、この関数だと `0.3333333...`

ピクチャ機能の `move` プロパティで細かくピクチャを動かしたい時に使用します。

2つ目の引数（分母）に `0` を指定した場合、強制的に `Infinity` が出力されます（現行の割り算と同じでは `0` が出力されるので仕様が異なります）。

## `FLOOR` `CEIL` `ROUND` 関数
小数点以下の処理を行う関数です。

- `FLOOR` は切り捨て
- `CEIL` は切り上げ
- `ROUND` は四捨五入

## `IS_NAN` 関数
不正な数値として扱われた場合に `NaN` が出力されることがあります。
（文字列同士の除算で `NaN` が出力されます）

この関数は `NaN` かどうかを判定します。

## 動作確認
- [x] `DIV` 関数で割り切れる割り算ができる
- [x] `DIV` 関数で余りが発生する割り算をすると小数点以下が発生する
- [x] `DIV` 関数でゼロ除算をすると `Infinity` が返ってくる
- [x] `DIV` 関数で文字列除算をすると `NaN` が返ってくる
- [x] `FLOOR` 関数で小数点以下の切り捨てができる
- [x] `CEIL` 関数で小数点以下の切り上げができる
- [x] `ROUND` 関数で `0.5` 未満の小数点が切り捨てになる
- [x] `ROUND` 関数で `0.5` 以上の小数点が切り上げになる
- [x] 文字列除算した結果を `IS_NAN` 関数に与えると `true` が返ってくる
- [x] ゼロ除算した結果を `IS_NAN` 関数に与えると `false` が返ってくる
- [x] 小数点ありの除算した結果を `IS_NAN` 関数に与えると `false` が返ってくる
