### PR TITLE
feat: WWA Script からロードセーブウィンドウ呼び出し

### DIFF
--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -259,6 +259,9 @@ function convertCallExpression(node: Acorn.CallExpression): Wwa.WWANode  {
     case "CHANGE_SOUND_ATTACK":
     case "CHANGE_SOUND_DECISION":
     case "SORT":
+    case "OPEN_QUICK_SAVE_WINDOW":
+    case "OPEN_QUICK_LOAD_WINDOW":
+    case "OPEN_RESTART_GAME_WINDOW":
       return execSystemDefinedFunctionCall(node.arguments, functionName);
     default:
       return {

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -1186,6 +1186,15 @@ export class EvalCalcWwaNode {
         } : undefined));
         return;
       }
+      case "OPEN_QUICK_SAVE_WINDOW": {
+        return this.generator.wwa.openQuickSaveWindow();
+      }
+      case "OPEN_QUICK_LOAD_WINDOW": {
+        return this.generator.wwa.openQuickLoadWindow();
+      }
+      case "OPEN_RESTART_GAME_WINDOW": {
+        return this.generator.wwa.openRestartGameWindow();
+      }
       default:
         throw new Error("未定義の関数が指定されました: "+node.functionName);
     }

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -1099,17 +1099,9 @@ export class WWA {
                 }
             });
 
-            util.$id("button-save").addEventListener("click", () => {
-                if (this._player.isControllable() || (this._messageWindow.isItemMenuChoice())) {
-                    this.onselectbutton(SidebarButton.QUICK_SAVE);
-                }
-            });
-
-            util.$id("button-restart").addEventListener("click", () => {
-                if (this._player.isControllable() || (this._messageWindow.isItemMenuChoice())) {
-                    this.onselectbutton(SidebarButton.RESTART_GAME);
-                }
-            });
+            util.$id("button-load").addEventListener("click", this.openQuickLoadWindow.bind(this));
+            util.$id("button-save").addEventListener("click", this.openQuickSaveWindow.bind(this));
+            util.$id("button-restart").addEventListener("click", this.openRestartGameWindow.bind(this));
             util.$id("button-gotowwa").addEventListener("click", () => {
                 if (this._player.isControllable() || (this._messageWindow.isItemMenuChoice())) {
                     this.onselectbutton(SidebarButton.GOTO_WWA, false, false);
@@ -7251,6 +7243,30 @@ font-weight: bold;
 
     public cancelManualPause(): void {
         this._player.clearWaitingMessageOrManualPause();
+    }
+
+    public openQuickSaveWindow(): boolean {
+        if (this._player.isControllable() || (this._messageWindow.isItemMenuChoice())) {
+            this.onselectbutton(SidebarButton.QUICK_SAVE);
+            return true;
+        }
+        return false;
+    }
+
+    public openQuickLoadWindow(): boolean {
+        if (this._player.isControllable() || (this._messageWindow.isItemMenuChoice())) {
+            this.onselectbutton(SidebarButton.QUICK_LOAD);
+            return true;
+        }
+        return false;
+    }
+
+    public openRestartGameWindow(): boolean {
+        if (this._player.isControllable() || (this._messageWindow.isItemMenuChoice())) {
+            this.onselectbutton(SidebarButton.RESTART_GAME);
+            return true;
+        }
+        return false;
     }
 };
 


### PR DESCRIPTION
## OPEN_QUICK_SAVE_WINDOW()
QuickSaveボタンを押した場合と同じ挙動をします。プレイヤーが操作不能な場合は実行されません。
ウィンドウのオープンに成功した場合はtrueを、失敗した場合はfalseを返します。

## OPEN_QUICK_LOAD_WINDOW()
Password/QuickLoadボタンを押した場合と同じ挙動をします。以下同文

## OPEN_RESTART_GAME_WINDOW()
RestartGameボタンを押した場合と同じ挙動をします。以下同文

## 確認事項
ゲームパッド操作でメニュー操作している時に壊れないか。