### PR TITLE
feat(battle-estimate): 戦闘予測ブロックを実装

### DIFF
--- a/packages/common-interface/src/wwa_data.ts
+++ b/packages/common-interface/src/wwa_data.ts
@@ -198,6 +198,7 @@ export interface WWAData {
 
     decisionSound?: number | string;
     attackSound?: number | string;
+    battleEstimateDisabled?: boolean;
 }
 
 export enum SystemSound {

--- a/packages/common-interface/src/wwa_system_message.ts
+++ b/packages/common-interface/src/wwa_system_message.ts
@@ -86,7 +86,11 @@ const _systemMessage = Object.freeze({
     defaultText: `ここでは移動速度を
 変更できません。`,
   },
-} as {[key in string]: Config});
+  BATTLE_REPORT_DISABLED: {
+    code: 601,
+    defaultText: `ここでは戦闘予測を表示できません。`,
+  }
+} as const satisfies {[key in string]: Config});
 
 export const keys = Object.keys(_systemMessage) as Key[];
 

--- a/packages/engine/src/wwa_data.ts
+++ b/packages/engine/src/wwa_data.ts
@@ -604,6 +604,7 @@ export enum MacroType {
     DELAYBGM = 64,
     SYSMSG = 65,
     PICTURE = 66,
+    DISABLE_BATTLE_REPORT = 67,
     GAMEPAD_BUTTON = 100,
     OLDMOVE = 101,
     LEGACY_IF = 10050
@@ -678,6 +679,7 @@ export var macrotable = {
     "$delaybgm": 64,
     "$sysmsg": 65,
     "$picture": 66,
+    "$disable_battle_report": 67,
     "$gamepad_button" : 100,
     "$oldmove": 101
 }

--- a/packages/engine/src/wwa_expression2/converter.ts
+++ b/packages/engine/src/wwa_expression2/converter.ts
@@ -264,6 +264,7 @@ function convertCallExpression(node: Acorn.CallExpression): Wwa.WWANode  {
     case "CHANGE_SOUND_ATTACK":
     case "CHANGE_SOUND_DECISION":
     case "SORT":
+    case "DISABLE_BATTLE_REPORT":
       return execSystemDefinedFunctionCall(node.arguments, functionName);
     default:
       return {

--- a/packages/engine/src/wwa_expression2/eval.ts
+++ b/packages/engine/src/wwa_expression2/eval.ts
@@ -1214,6 +1214,13 @@ export class EvalCalcWwaNode {
         } : undefined));
         return;
       }
+      case "DISABLE_BATTLE_REPORT": {
+        this._checkArgsLength(1, node);
+        const disabled = Boolean(this.evalWwaNode(node.value[0]));
+        this.generator.wwa.disableBattleEstimate(disabled);
+        return;
+
+      }
       default:
         throw new Error("未定義の関数が指定されました: "+node.functionName);
     }

--- a/packages/engine/src/wwa_macro.ts
+++ b/packages/engine/src/wwa_macro.ts
@@ -521,6 +521,10 @@ export class Macro {
                     this._executePictureMacro();
                     return {};
                 }
+                case MacroType.DISABLE_BATTLE_REPORT: {
+                    this._executeDisableBattleReportMacro();
+                    return {};
+                }
                 default: {
                     console.log("不明なマクロIDが実行されました:" + this.macroType);
                     return {};
@@ -1170,6 +1174,12 @@ export class Macro {
         }
         const definePartsType = this._evaluateIntValue(2, PartsType.OBJECT);
         this._wwa.setPictureRegistry(layerNumber, definePartsNumber, definePartsType, this._triggerParts.position);
+    }
+
+    private _executeDisableBattleReportMacro(): void {
+        this._concatEmptyArgs(1);
+        const disableBattleReportFlag = Boolean(this._evaluateIntValue(0));
+        this._wwa.disableBattleEstimate(disableBattleReportFlag);
     }
 
     private _executeDelayBgmMacro(): void {

--- a/packages/engine/src/wwa_main.ts
+++ b/packages/engine/src/wwa_main.ts
@@ -5417,6 +5417,16 @@ export class WWA {
         const yBottom = Math.min(this._wwaData.mapWidth - 1, cpParts.y + Consts.V_PARTS_NUM_IN_WINDOW - 1);
         const monsterList: Monster[] = [];
         this.playDecisionSound();
+        if (this._bottomButtonType === ControlPanelBottomButton.BATTLE_REPORT) {
+            (<HTMLDivElement>(util.$id(sidebarButtonCellElementID[SidebarButton.GOTO_WWA]))).classList.add("onpress");
+        }
+        if (this._wwaData.battleEstimateDisabled) {
+            this.registerSystemMessagePageByKey(SystemMessage.Key.BATTLE_REPORT_DISABLED);
+            if (this._wwaData.customSystemMessages[SystemMessage.Key.BATTLE_REPORT_DISABLED] === "BLANK") {
+                (<HTMLDivElement>(util.$id(sidebarButtonCellElementID[SidebarButton.GOTO_WWA]))).classList.remove("onpress");
+            }
+            return false;
+        }
         for (let x = xLeft; x <= xRight; x++) {
             for (let y= yTop; y <= yBottom; y++) {
                 const partsId = this._wwaData.mapObject[y][x];
@@ -5428,9 +5438,6 @@ export class WWA {
                 }
                 monsterList.push(this._createMonster(partsId, new Coord(x, y)));
             }
-        }
-        if (this._bottomButtonType === ControlPanelBottomButton.BATTLE_REPORT) {
-            (<HTMLDivElement>(util.$id(sidebarButtonCellElementID[SidebarButton.GOTO_WWA]))).classList.add("onpress");
         }
         if (monsterList.length === 0) {
             (<HTMLDivElement>(util.$id(sidebarButtonCellElementID[SidebarButton.GOTO_WWA]))).classList.remove("onpress");
@@ -7252,6 +7259,11 @@ font-weight: bold;
     public cancelManualPause(): void {
         this._player.clearWaitingMessageOrManualPause();
     }
+
+    public disableBattleEstimate(disabled: boolean): void {
+        this._wwaData.battleEstimateDisabled = disabled;
+    }
+
 };
 
 var isCopyRightClick = false;

--- a/packages/loader/src/infra/index.ts
+++ b/packages/loader/src/infra/index.ts
@@ -189,7 +189,8 @@ export function createDefaultWWAData(): WWAData {
         customSystemMessages: {},
         pictureRegistry: [],
         decisionSound: undefined,
-        attackSound: undefined
+        attackSound: undefined,
+        battleEstimateDisabled: undefined,
     };
 }
 


### PR DESCRIPTION
## マクロ
```
// 戦闘予測を無効化します
$disable_battle_report=1

// 戦闘予測無効化中に開こうとした場合、デフォルトでは 「ここでは戦闘予測を表示できません。」というシステムメッセージが表示されますが、これを変更できます。
$sysmsg=601,aaaa
$sysmsg=BATTLE_REPORT_DISABLED,aaaa

// BLANK も指定できます。この場合、モンスターが画面内にいない場合と同じ挙動になります
$sysmsg=601,BLANK
$sysmsg=BATTLE_REPORT_DISABLED,BLANK

// 戦闘予測を再度有効化します
$disable_battle_report=0
```
## WWA Script
```js
// 戦闘予測を無効化します
DISABLE_BATTLE_REPORT(true);

// 戦闘予測無効化中に開こうとした場合、デフォルトでは 「ここでは戦闘予測を表示できません。」というシステムメッセージが表示されますが、これを変更できます。
CHANGE_SYSMSG(601, "aaaa");
CHANGE_SYSMSG("BATTLE_REPORT_DISABLED", "aaaa");

// BLANK も指定できます。この場合、モンスターが画面内にいない場合と同じ挙動になります
CHANGE_SYSMSG(601, "BLANK");
CHANGE_SYSMSG("BATTLE_REPORT_DISABLED", "BLANK");

// 戦闘予測を再度有効化します
DISABLE_BATTLE_REPORT(false);
```